### PR TITLE
Add HF PEFT adapter support and thread `hf_peft_path` through LLMClient

### DIFF
--- a/Simulation/README.md
+++ b/Simulation/README.md
@@ -136,6 +136,29 @@ llm_model: str = "gpt-4"
 llm_temperature: float = 1.0
 ```
 
+#### Backend Selection
+
+By default, the simulation uses OpenAI. To switch providers, set `LLM_BACKEND`:
+
+```bash
+# OpenAI (default)
+export OPENAI_API_KEY="your-api-key"
+
+# vLLM (OpenAI-compatible server)
+export LLM_BACKEND="vllm"
+export VLLM_BASE_URL="http://localhost:8000/v1"
+# Optional: VLLM_API_KEY (if your server requires it)
+
+# Hugging Face Inference API
+export LLM_BACKEND="hf"
+export HF_MODEL_ID="meta-llama/Llama-3.1-8B-Instruct"
+export HF_TOKEN="your-hf-token"
+# Optional: local PEFT adapter path (requires transformers + peft)
+export HF_PEFT_PATH="/path/to/adapter"
+```
+
+The `LLMClient` API is unchanged; you can continue using `LLMClient(model=..., temperature=...)`. For Hugging Face, `model` defaults to `HF_MODEL_ID` unless you pass one explicitly. For vLLM, `model` is forwarded to the server (e.g., the model name you started vLLM with).
+
 ## Architecture
 
 ### Module Overview
@@ -265,6 +288,8 @@ This format matches the existing data structure from `player-rounds.csv`.
 - Using GPT-4: ~$0.045 per 1K tokens
 - Typical prompt: ~500 tokens, response: ~50 tokens
 - **Estimated cost per experiment: $2-5 USD**
+
+For open-source backends (vLLM or Hugging Face), the client does not assign any per-token cost (cost remains $0 in the usage summary).
 
 To track costs in real-time:
 ```python

--- a/Simulation/llm_client.py
+++ b/Simulation/llm_client.py
@@ -5,10 +5,12 @@ This module provides a wrapper around the OpenAI API with robust error handling,
 exponential backoff for rate limits, and cost tracking.
 """
 
-from openai import OpenAI, RateLimitError, APIError
+from dataclasses import dataclass
 import os
 import time
 from typing import Optional
+
+from openai import OpenAI, RateLimitError, APIError
 
 # Generic system prompt for all agents
 SYSTEM_PROMPT = """You are a participant in an economic game theory experiment. Your goal is to maximize your total earnings.
@@ -24,32 +26,32 @@ Follow these guidelines:
 Be strategic but realistic in your choices."""
 
 
-class LLMClient:
-    """Client for making OpenAI API calls with retry logic.
+@dataclass
+class BackendResult:
+    """Container for backend responses and usage metadata."""
 
-    This class handles:
-    - API authentication
-    - Request execution with exponential backoff on rate limits
-    - Error handling and logging
-    - Token usage tracking
-    """
+    text: str
+    tokens_used: int = 0
+    cost_usd: float = 0.0
 
-    def __init__(
+
+class BaseLLMBackend:
+    """Interface for LLM backends."""
+
+    def call(
         self,
-        model: str = "gpt-4",
-        temperature: float = 1.0,
-        api_key: Optional[str] = None
-    ):
-        """Initialize LLM client.
+        user_prompt: str,
+        system_prompt: str,
+        max_tokens: int
+    ) -> BackendResult:
+        """Execute a request against the backend."""
+        raise NotImplementedError
 
-        Args:
-            model: OpenAI model name (e.g., "gpt-4", "gpt-4o", "gpt-3.5-turbo")
-            temperature: Sampling temperature (0.0 = deterministic, 2.0 = very random)
-            api_key: OpenAI API key (if None, reads from OPENAI_API_KEY env var)
 
-        Raises:
-            ValueError: If API key is not provided and not found in environment
-        """
+class OpenAIBackend(BaseLLMBackend):
+    """OpenAI-backed implementation."""
+
+    def __init__(self, model: str, temperature: float, api_key: Optional[str]):
         self.model = model
         self.temperature = temperature
         self.api_key = api_key or os.getenv("OPENAI_API_KEY")
@@ -60,13 +62,227 @@ class LLMClient:
                 "or pass api_key parameter."
             )
 
-        # Initialize OpenAI client (new style)
         self.client = OpenAI(api_key=self.api_key)
+
+    def call(
+        self,
+        user_prompt: str,
+        system_prompt: str,
+        max_tokens: int
+    ) -> BackendResult:
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt}
+            ],
+            temperature=self.temperature,
+            max_tokens=max_tokens
+        )
+
+        result_text = response.choices[0].message.content.strip()
+        tokens_used = response.usage.total_tokens
+
+        if 'gpt-4o' in self.model.lower():
+            cost_usd = tokens_used * 0.006 / 1000
+        elif 'gpt-4' in self.model.lower():
+            cost_usd = tokens_used * 0.045 / 1000
+        else:
+            cost_usd = tokens_used * 0.001 / 1000
+
+        return BackendResult(text=result_text, tokens_used=tokens_used, cost_usd=cost_usd)
+
+
+class VLLMBackend(BaseLLMBackend):
+    """vLLM OpenAI-compatible backend."""
+
+    def __init__(
+        self,
+        model: str,
+        temperature: float,
+        api_key: Optional[str],
+        base_url: Optional[str]
+    ):
+        # Configuration:
+        # - LLM_BACKEND=vllm
+        # - VLLM_BASE_URL=http://localhost:8000/v1 (OpenAI-compatible endpoint)
+        # - VLLM_API_KEY=... (optional; vLLM commonly ignores this)
+        self.model = model
+        self.temperature = temperature
+        self.base_url = base_url or os.getenv("VLLM_BASE_URL", "http://localhost:8000/v1")
+        self.api_key = api_key or os.getenv("VLLM_API_KEY") or "EMPTY"
+        self.client = OpenAI(api_key=self.api_key, base_url=self.base_url)
+
+    def call(
+        self,
+        user_prompt: str,
+        system_prompt: str,
+        max_tokens: int
+    ) -> BackendResult:
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt}
+            ],
+            temperature=self.temperature,
+            max_tokens=max_tokens
+        )
+
+        result_text = response.choices[0].message.content.strip()
+        tokens_used = getattr(response.usage, "total_tokens", 0) or 0
+        return BackendResult(text=result_text, tokens_used=tokens_used, cost_usd=0.0)
+
+
+class HFBackend(BaseLLMBackend):
+    """Hugging Face Inference backend using huggingface_hub."""
+
+    def __init__(
+        self,
+        model: Optional[str],
+        temperature: float,
+        token: Optional[str],
+        peft_adapter_path: Optional[str] = None
+    ):
+        # Configuration:
+        # - LLM_BACKEND=hf
+        # - HF_MODEL_ID=meta-llama/Llama-3.1-8B-Instruct
+        # - HF_TOKEN=... (required for gated/private models)
+        # - HF_PEFT_PATH=/path/to/adapter (optional; enables local PEFT loading)
+
+        self.model = model or os.getenv("HF_MODEL_ID")
+        if not self.model:
+            raise ValueError(
+                "HF model not found. Please set HF_MODEL_ID environment variable "
+                "or pass model parameter."
+            )
+        self.temperature = temperature
+        self.peft_adapter_path = peft_adapter_path or os.getenv("HF_PEFT_PATH")
+        if self.peft_adapter_path:
+            from peft import PeftModel
+            from transformers import AutoModelForCausalLM, AutoTokenizer
+            import torch
+
+            self.tokenizer = AutoTokenizer.from_pretrained(self.model)
+            base_model = AutoModelForCausalLM.from_pretrained(self.model)
+            self.model_runner = PeftModel.from_pretrained(base_model, self.peft_adapter_path)
+            self.model_runner.eval()
+            if torch.cuda.is_available():
+                self.model_runner.to("cuda")
+        else:
+            from huggingface_hub import InferenceClient
+            self.client = InferenceClient(model=self.model, token=token or os.getenv("HF_TOKEN"))
+
+    def call(
+        self,
+        user_prompt: str,
+        system_prompt: str,
+        max_tokens: int
+    ) -> BackendResult:
+        # Prefer chat-completions when available so system/user roles are preserved.
+        if self.peft_adapter_path:
+            prompt = f"{system_prompt}\n\nUser: {user_prompt}\nAssistant:"
+            inputs = self.tokenizer(prompt, return_tensors="pt")
+            if hasattr(self.model_runner, "device"):
+                inputs = {key: value.to(self.model_runner.device) for key, value in inputs.items()}
+            outputs = self.model_runner.generate(
+                **inputs,
+                max_new_tokens=max_tokens,
+                do_sample=self.temperature > 0,
+                temperature=self.temperature
+            )
+            result_text = self.tokenizer.decode(outputs[0], skip_special_tokens=True)
+            result_text = result_text.split("Assistant:", maxsplit=1)[-1].strip()
+        elif hasattr(self.client, "chat_completion"):
+            response = self.client.chat_completion(
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt}
+                ],
+                max_tokens=max_tokens,
+                temperature=self.temperature
+            )
+            result_text = response.choices[0].message.content.strip()
+        else:
+            # Fallback for text-generation models that do not support chat:
+            # keep a lightweight, explicit prompt format.
+            prompt = f"{system_prompt}\n\nUser: {user_prompt}\nAssistant:"
+            response = self.client.text_generation(
+                prompt,
+                max_new_tokens=max_tokens,
+                temperature=self.temperature,
+                do_sample=self.temperature > 0
+            )
+            result_text = response.strip()
+
+        return BackendResult(text=result_text, tokens_used=0, cost_usd=0.0)
+
+
+class LLMClient:
+    """Client for making LLM API calls with retry logic.
+
+    This class handles:
+    - Backend selection (OpenAI, vLLM, Hugging Face)
+    - Request execution with exponential backoff on rate limits
+    - Error handling and logging
+    - Token usage tracking
+    """
+
+    def __init__(
+        self,
+        model: str = "gpt-4",
+        temperature: float = 1.0,
+        api_key: Optional[str] = None,
+        backend: Optional[str] = None,
+        vllm_base_url: Optional[str] = None,
+        hf_token: Optional[str] = None,
+        hf_peft_path: Optional[str] = None
+    ):
+        """Initialize LLM client.
+
+        Args:
+            model: OpenAI model name (e.g., "gpt-4", "gpt-4o", "gpt-3.5-turbo")
+            temperature: Sampling temperature (0.0 = deterministic, 2.0 = very random)
+            api_key: OpenAI API key (if None, reads from OPENAI_API_KEY env var)
+            backend: Backend selector ("openai", "vllm", "hf"). Defaults to LLM_BACKEND env var.
+            vllm_base_url: Optional override for VLLM_BASE_URL
+            hf_token: Optional override for HF_TOKEN
+            hf_peft_path: Optional override for HF_PEFT_PATH (local PEFT adapter)
+
+        Raises:
+            ValueError: If required backend configuration is missing
+        """
+        self.model = model
+        self.temperature = temperature
+        self.api_key = api_key
 
         # Track usage
         self.total_calls = 0
         self.total_tokens = 0
         self.total_cost_usd = 0.0
+
+        backend_name = (backend or os.getenv("LLM_BACKEND", "openai")).lower()
+        if backend_name == "openai":
+            self.backend = OpenAIBackend(model=self.model, temperature=self.temperature, api_key=self.api_key)
+        elif backend_name == "vllm":
+            self.backend = VLLMBackend(
+                model=self.model,
+                temperature=self.temperature,
+                api_key=self.api_key,
+                base_url=vllm_base_url
+            )
+        elif backend_name == "hf":
+            hf_model = None if self.model == "gpt-4" else self.model
+            self.backend = HFBackend(
+                model=hf_model,
+                temperature=self.temperature,
+                token=hf_token,
+                peft_adapter_path=hf_peft_path
+            )
+        else:
+            raise ValueError(
+                f"Unknown LLM backend '{backend_name}'. Expected 'openai', 'vllm', or 'hf'."
+            )
 
     def call(
         self,
@@ -75,7 +291,7 @@ class LLMClient:
         max_retries: int = 3,
         max_tokens: int = 500
     ) -> str:
-        """Call OpenAI API with retry logic.
+        """Call LLM backend with retry logic.
 
         Args:
             user_prompt: The user message to send
@@ -91,38 +307,18 @@ class LLMClient:
         """
         for attempt in range(max_retries):
             try:
-                response = self.client.chat.completions.create(
-                    model=self.model,
-                    messages=[
-                        {"role": "system", "content": system_prompt},
-                        {"role": "user", "content": user_prompt}
-                    ],
-                    temperature=self.temperature,
+                result = self.backend.call(
+                    user_prompt=user_prompt,
+                    system_prompt=system_prompt,
                     max_tokens=max_tokens
                 )
 
-                # Extract response
-                result = response.choices[0].message.content.strip()
-
                 # Track usage
                 self.total_calls += 1
-                tokens_used = response.usage.total_tokens
-                self.total_tokens += tokens_used
+                self.total_tokens += result.tokens_used
+                self.total_cost_usd += result.cost_usd
 
-                # Estimate cost (approximate rates)
-                if 'gpt-4o' in self.model.lower():
-                    # GPT-4o: ~$0.0025/1K prompt tokens, ~$0.01/1K completion tokens
-                    # Rough estimate: average to $0.006/1K tokens
-                    self.total_cost_usd += tokens_used * 0.006 / 1000
-                elif 'gpt-4' in self.model.lower():
-                    # GPT-4: ~$0.03/1K prompt tokens, ~$0.06/1K completion tokens
-                    # Rough estimate: average to $0.045/1K tokens
-                    self.total_cost_usd += tokens_used * 0.045 / 1000
-                else:
-                    # GPT-3.5-turbo: ~$0.001/1K tokens
-                    self.total_cost_usd += tokens_used * 0.001 / 1000
-
-                return result
+                return result.text
 
             except RateLimitError as e:
                 if attempt < max_retries - 1:
@@ -143,7 +339,7 @@ class LLMClient:
                     raise
 
             except Exception as e:
-                print(f"Unexpected error calling OpenAI API: {e}")
+                print(f"Unexpected error calling LLM backend: {e}")
                 if attempt == max_retries - 1:
                     raise
                 time.sleep(2 ** attempt)


### PR DESCRIPTION
### Motivation

- Enable running Hugging Face models with local PEFT adapters so users can specify an adapter path for on-device inference.
- Allow selecting Hugging Face as a backend while preserving the existing `LLMClient` API and enabling configuration via env vars or constructor args.

### Description

- Add optional PEFT adapter loading to the HF backend so when `HF_PEFT_PATH` (or `peft_adapter_path` / `hf_peft_path`) is provided the code loads the base model with `transformers` and wraps it with `peft.PeftModel` for local generation.
- Thread an `hf_peft_path` parameter through `LLMClient` and pass it into `HFBackend` so callers can specify the adapter path via `LLMClient(..., hf_peft_path=...)` or the `HF_PEFT_PATH` env var.
- Update `HFBackend.call` to run generation through the PEFT-wrapped model with tokenization and device placement, and trim the prompt prefix (splits on `Assistant:`) to return only the assistant reply.
- Document the new `HF_PEFT_PATH` env var in `Simulation/README.md` and clarify that open-source backends (vLLM/HF) are treated as zero-cost in usage summaries.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972280e561c8331a8c40dc09cf695c5)