### PR TITLE
Add manifest-driven validation runner

### DIFF
--- a/Simulation/README.md
+++ b/Simulation/README.md
@@ -314,6 +314,19 @@ Generate or refresh the manifest with:
 python scripts/export_validation_configs.py
 ```
 
+Run the full validation batch directly from the manifest (each `experiment_id`
+becomes its output directory under `experiments/`):
+
+```bash
+python run_validation_experiments.py --manifest-path data/validation_configs.json
+```
+
+To reduce console output while running the batch:
+
+```bash
+python run_validation_experiments.py --manifest-path data/validation_configs.json --quiet
+```
+
 ### CSV Format
 
 ```csv

--- a/Simulation/config.py
+++ b/Simulation/config.py
@@ -40,10 +40,10 @@ class PGGConfig:
     5. Incentive Mechanisms:
        - punishment_enabled: Whether punishment is available
        - punishment_cost: Cost to punisher per unit (1-4 coins)
-       - punishment_impact: Deduction to target per unit (1-4 coins)
+       - punishment_impact: Deduction to target per unit (1-11 coins)
        - reward_enabled: Whether rewards are available
        - reward_cost: Cost to rewarder per unit (1-4 coins)
-       - reward_impact: Addition to target per unit (0.5-1.5 coins)
+       - reward_impact: Addition to target per unit (0.5-5 coins)
     """
 
     # ===== Game Structure =====
@@ -67,12 +67,12 @@ class PGGConfig:
     # ===== Punishment Mechanism =====
     punishment_enabled: bool = False
     punishment_cost: int = 1  # Cost to punisher per unit (1-4)
-    punishment_impact: int = 3  # Deduction to target per unit (1-4)
+    punishment_impact: int = 3  # Deduction to target per unit (1-11)
 
     # ===== Reward Mechanism =====
     reward_enabled: bool = False
     reward_cost: int = 1  # Cost to rewarder per unit (1-4)
-    reward_impact: float = 1.0  # Addition to target per unit (0.5-1.5)
+    reward_impact: float = 1.0  # Addition to target per unit (0.5-5)
 
     # ===== LLM Settings =====
     llm_model: str = "gpt-4o"
@@ -107,12 +107,16 @@ class PGGConfig:
         # Punishment validation
         if self.punishment_enabled:
             assert 1 <= self.punishment_cost <= 4, f"punishment_cost must be 1-4, got {self.punishment_cost}"
-            assert 1 <= self.punishment_impact <= 4, f"punishment_impact must be 1-4, got {self.punishment_impact}"
+            assert 1 <= self.punishment_impact <= 11, (
+                f"punishment_impact must be 1-11, got {self.punishment_impact}"
+            )
 
         # Reward validation
         if self.reward_enabled:
             assert 1 <= self.reward_cost <= 4, f"reward_cost must be 1-4, got {self.reward_cost}"
-            assert 0.5 <= self.reward_impact <= 1.5, f"reward_impact must be 0.5-1.5, got {self.reward_impact}"
+            assert 0.5 <= self.reward_impact <= 5, (
+                f"reward_impact must be 0.5-5, got {self.reward_impact}"
+            )
 
 
 # ===== Example Configurations =====

--- a/Simulation/config_loader.py
+++ b/Simulation/config_loader.py
@@ -1,0 +1,47 @@
+"""Utilities for loading PGG configs from a manifest file."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import fields
+from pathlib import Path
+from typing import List, Tuple
+
+from config import PGGConfig
+
+
+def _filter_config_fields(config_data: dict) -> dict:
+    """Filter manifest config data down to PGGConfig fields."""
+    field_names = {field.name for field in fields(PGGConfig)}
+    return {key: value for key, value in config_data.items() if key in field_names}
+
+
+def load_manifest(manifest_path: Path) -> List[Tuple[str, PGGConfig]]:
+    """Load a validation manifest and return (experiment_id, config) pairs.
+
+    Args:
+        manifest_path: Path to a JSON manifest exported by
+            scripts/export_validation_configs.py.
+
+    Returns:
+        List of (experiment_id, PGGConfig) tuples.
+    """
+    entries = json.loads(manifest_path.read_text())
+    if not isinstance(entries, list):
+        raise ValueError(f"Manifest must be a list, got {type(entries).__name__}")
+
+    configs: List[Tuple[str, PGGConfig]] = []
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise ValueError(f"Manifest entry {index} must be a dict.")
+
+        experiment_id = entry.get("experiment_id")
+        if not experiment_id:
+            raise ValueError(f"Manifest entry {index} missing experiment_id.")
+
+        config_data = dict(entry.get("config", {}))
+        config_data.pop("multiplier", None)
+        config = PGGConfig(**_filter_config_fields(config_data))
+        configs.append((experiment_id, config))
+
+    return configs

--- a/run_validation_experiments.py
+++ b/run_validation_experiments.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Run validation experiments from a manifest file."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+# Add Simulation to path
+sys.path.insert(0, str(Path(__file__).parent / "Simulation"))
+
+from config_loader import load_manifest
+from main import run_experiment
+
+
+DEFAULT_MANIFEST_PATH = Path("data/validation_configs.json")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run validation experiments from a JSON manifest."
+    )
+    parser.add_argument(
+        "--manifest-path",
+        type=Path,
+        default=DEFAULT_MANIFEST_PATH,
+        help="Path to the validation manifest JSON.",
+    )
+    parser.add_argument(
+        "--num-games",
+        type=int,
+        default=1,
+        help="Number of games to run per experiment.",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Disable verbose per-round output.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    configs = load_manifest(args.manifest_path)
+    verbose = not args.quiet
+
+    for experiment_id, config in configs:
+        run_experiment(experiment_id, config, num_games=args.num_games, verbose=verbose)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a simple way to run the exported validation manifest so many pre-generated `VALIDATION_*` configs can be executed as a batch.
- Convert each manifest entry into a `PGGConfig` and ensure the manifest `experiment_id` becomes the experiment output directory name.
- Make the manifest-compatible range values acceptable by the config validation logic.

### Description
- Add `Simulation/config_loader.py` with `load_manifest(manifest_path)` that filters manifest entries to the `PGGConfig` fields and returns `(experiment_id, PGGConfig)` pairs, removing computed fields like `multiplier` before construction.
- Add top-level CLI `run_validation_experiments.py` that loads the manifest and calls `main.run_experiment(experiment_id, config, num_games=...)` for each entry, using `experiment_id` as the output folder name and providing `--manifest-path`, `--num-games`, and `--quiet` flags.
- Relax validation ranges in `Simulation/config.py` for `punishment_impact` (now up to 11) and `reward_impact` (now up to 5) and update doc comments to reflect the expanded ranges.
- Update `Simulation/README.md` to document how to export the manifest and run the full validation batch with `python run_validation_experiments.py` and the `--quiet` option.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69724a8cd8dc8331b7c3634f0e1dedef)