### PR TITLE
Auto LLM backend routing with vLLM health check and HF fallback

### DIFF
--- a/Simulation/README.md
+++ b/Simulation/README.md
@@ -138,11 +138,19 @@ llm_temperature: float = 1.0
 
 #### Backend Selection
 
-By default, the simulation uses OpenAI. To switch providers, set `LLM_BACKEND`:
+By default, the simulation uses OpenAI. To switch providers, set `LLM_BACKEND` or enable
+auto routing with `LLM_BACKEND_STRATEGY=auto` (or `LLM_BACKEND=auto`):
 
 ```bash
 # OpenAI (default)
 export OPENAI_API_KEY="your-api-key"
+
+# Auto routing (OpenAI for gpt-4/gpt-4o/gpt-3.5 prefixes, otherwise vLLM if healthy, else HF)
+export LLM_BACKEND_STRATEGY="auto"
+export OPENAI_API_KEY="your-api-key"
+export VLLM_BASE_URL="http://localhost:8000/v1"
+export HF_MODEL_ID="meta-llama/Llama-3.1-8B-Instruct"
+export HF_TOKEN="your-hf-token"
 
 # vLLM (OpenAI-compatible server)
 export LLM_BACKEND="vllm"


### PR DESCRIPTION
### Motivation
- Provide an automatic backend selection strategy so the simulation can prefer OpenAI for known OpenAI model prefixes and otherwise use local/self-hosted FOSS servers when possible.
- Ensure the vLLM endpoint is healthy before using it and automatically fall back to Hugging Face inference if vLLM is unavailable.
- Make routing configurable via environment variables so operators can opt into `auto` behavior without changing application code.

### Description
- Added `_is_openai_model` to detect OpenAI model name prefixes (`gpt-4o`, `gpt-4`, `gpt-3.5`, `gpt-35`) and `_vllm_is_available` which performs a quick GET to `VLLM_BASE_URL/models` (using `urllib` with a 2s timeout) to check vLLM health.
- Introduced `LLM_BACKEND_STRATEGY` (and accept `LLM_BACKEND=auto`) and updated `LLMClient` selection logic to interpret `auto` as OpenAI for matching prefixes and otherwise attempt vLLM; if vLLM is unreachable the client now falls back to the `HFBackend` automatically.
- Adjusted HF backend selection logic to avoid mapping OpenAI-specific model names into HF, updated the module docstring to describe the auto-routing behavior, and added console messaging when falling back from vLLM to HF.
- Updated `Simulation/README.md` to document the new `LLM_BACKEND_STRATEGY=auto` example and explain the routing rules and environment variables (`OPENAI_API_KEY`, `VLLM_BASE_URL`, `VLLM_API_KEY`, `HF_MODEL_ID`, `HF_TOKEN`, `HF_PEFT_PATH`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69724d8adce48331b86612a8ce432151)