### PR TITLE
Clarify punishment/reward stage labeling and use `punishment_reward` prompt_type

### DIFF
--- a/Simulation/README.md
+++ b/Simulation/README.md
@@ -275,9 +275,19 @@ experiments/
     {experiment_name}/
         config.json          # Full configuration
         game_log.csv        # Round-by-round data
+        raw_responses.csv   # Raw LLM outputs with prompt_type labels
+        chat_messages.csv   # Per-round chat messages
+        redistribution_details.csv  # Punishment/reward action details
         prompts/            # Individual prompts (optional)
             {game_id}_r{round}_{agent_id}_{type}.txt
 ```
+
+### Raw Responses Prompt Types
+
+`raw_responses.csv` includes a `prompt_type` column with values such as `chat`, `contribution`,
+and `punishment_reward`. The punishment/reward prompt type was previously logged as
+`redistribution`; update any readers that filter on `redistribution` to also accept
+`punishment_reward` when working with newer logs.
 
 ### Validation Config Manifest
 

--- a/Simulation/agent.py
+++ b/Simulation/agent.py
@@ -117,7 +117,7 @@ class LLMAgent:
         """Get punishment/reward decisions from LLM.
 
         Args:
-            prompt: Prompt describing other players and asking for redistribution
+            prompt: Prompt describing other players and asking for punishments/rewards
             num_targets: Expected number of targets (length of output array)
 
         Returns:
@@ -128,7 +128,7 @@ class LLMAgent:
 
         # Store in memory
         self.memory.append({
-            "type": "redistribution",
+            "type": "punishment_reward",
             "prompt": prompt,
             "response": response,
             "num_targets": num_targets

--- a/Simulation/logger.py
+++ b/Simulation/logger.py
@@ -292,7 +292,7 @@ class ExperimentLogger:
             round_num: Round number
             agent_id: Agent identifier
             avatar_name: Agent's avatar name
-            prompt_type: Type of prompt (contribution/chat/redistribution)
+            prompt_type: Type of prompt (contribution/chat/punishment_reward)
             raw_response: The raw LLM response text
             parsed_result: The parsed/extracted value
         """
@@ -374,7 +374,7 @@ class ExperimentLogger:
             game_id: Game identifier
             round_num: Round number
             agent_id: Agent identifier
-            prompt_type: Type of prompt (e.g., "contribution", "redistribution", "chat")
+            prompt_type: Type of prompt (e.g., "contribution", "punishment_reward", "chat")
             prompt: The full prompt text
         """
         prompt_dir = self.base_dir / "prompts"

--- a/Simulation/prompt_builder.py
+++ b/Simulation/prompt_builder.py
@@ -7,7 +7,7 @@ implementing the "Agent Perception" layer that determines what LLMs see.
 Key features:
 - Scenario descriptions explaining game rules
 - Contribution prompts with framing (opt-in vs opt-out)
-- Redistribution prompts with visibility filtering
+- Punishment/reward prompts with visibility filtering
 - Chat prompts (if communication enabled)
 - Historical context from previous rounds
 """
@@ -135,7 +135,9 @@ class PromptBuilder:
         lines.append("")  # Blank line
 
         # Punishment/Reward
-        lines.append("After contribution and redistribution, you will see how much each player contributed to the public fund.")
+        lines.append(
+            "After contribution and public fund redistribution, you will see how much each player contributed to the public fund."
+        )
 
         if self.config.punishment_enabled:
             lines.append(
@@ -289,7 +291,7 @@ class PromptBuilder:
 
         return "\n".join(lines)
 
-    def build_redistribution_prompt(
+    def build_punishment_reward_prompt(
         self,
         agent_id: str,
         agent_name: str,
@@ -309,11 +311,11 @@ class PromptBuilder:
             current_wallet: Current wallet balance after contribution stage (optional)
 
         Returns:
-            str: Formatted redistribution prompt
+            str: Formatted punishment/reward prompt
         """
         lines = []
 
-        lines.append("### Redistribution Stage: Decide on punishments and/or rewards")
+        lines.append("### Punishment/Reward Stage: Decide on punishments and/or rewards")
 
         # Show contributions
         if self.config.peer_outcome_visibility:
@@ -397,7 +399,7 @@ class PromptBuilder:
 
         # Redistribution stage
         total_contrib = sum(round_state.contributions.values())
-        lines.append(f"### Redistribution Stage")
+        lines.append("### Redistribution Stage (Public Fund Allocation)")
         lines.append(
             f"Total group contribution is {total_contrib} {pluralize(total_contrib)}, "
             f"multiplied by {self.config.multiplier} => {round_state.public_fund} {pluralize(round_state.public_fund)} "
@@ -414,6 +416,7 @@ class PromptBuilder:
 
         # Punishment/Reward feedback (anonymity-dependent)
         if self.config.punishment_enabled or self.config.reward_enabled:
+            lines.append("### Punishment/Reward Stage")
             # Calculate what this agent received
             punishments_received = []
             rewards_received = []


### PR DESCRIPTION
### Motivation
- Make stage names and logs unambiguous by having "Redistribution" refer only to the public-fund allocation and naming the action phase explicitly as Punishment/Reward.
- Ensure prompt files and raw-response logs reflect the action-phase naming so downstream readers can distinguish public-fund redistribution from punishment/reward actions.

### Description
- Renamed the action-phase prompt builder from `build_redistribution_prompt` to `build_punishment_reward_prompt` and updated its header to `### Punishment/Reward Stage` in `Simulation/prompt_builder.py` and clarified the scenario text to call out public fund redistribution separately.
- Updated round-history formatting in `Simulation/prompt_builder.py` to label the public-fund allocation as `### Redistribution Stage (Public Fund Allocation)` and to include `### Punishment/Reward Stage` for received punishments/rewards.
- Updated runtime output and logging in `Simulation/main.py` to print `Stage 4: Punishment/Reward Stage`, to call `build_punishment_reward_prompt`, and to save/label prompts with `prompt_type` = `punishment_reward` instead of `redistribution`.
- Changed agent memory entries in `Simulation/agent.py` to record the action-phase interactions as `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69727141c21483319e20307163865bfa)