### PR TITLE
Extract debug logging helpers into Simulation_robin/debug.py

### DIFF
--- a/Simulation_robin/debug.py
+++ b/Simulation_robin/debug.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Dict, Optional
+
+
+def compact_text(text: Optional[str], limit: int = 200) -> Optional[str]:
+    if text is None:
+        return None
+    return text[:limit]
+
+
+def sha256_text(text: Optional[str]) -> Optional[str]:
+    if text is None:
+        return None
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def build_debug_record(
+    *,
+    game_id: str,
+    round_idx: int,
+    agent: str,
+    phase: str,
+    dt_sec: float,
+    prompt: str,
+    raw_output: str,
+    debug_level: str,
+    excerpt_chars: int = 200,
+) -> Dict[str, Any]:
+    record: Dict[str, Any] = {
+        "game": game_id,
+        "round": round_idx,
+        "agent": agent,
+        "phase": phase,
+        "dt_sec": dt_sec,
+    }
+    if debug_level == "compact":
+        record.update({
+            "prompt_excerpt": compact_text(prompt, excerpt_chars),
+            "prompt_sha256": sha256_text(prompt),
+            "output_excerpt": compact_text(raw_output, excerpt_chars),
+            "output_sha256": sha256_text(raw_output),
+        })
+    else:
+        record.update({
+            "prompt_full": prompt,
+            "raw_output_full": raw_output,
+        })
+    return record
+
+
+def build_full_debug_record(
+    *,
+    game_id: str,
+    round_idx: int,
+    agent: str,
+    phase: str,
+    dt_sec: float,
+    prompt: str,
+    raw_output: str,
+) -> Dict[str, Any]:
+    return {
+        "game": game_id,
+        "round": round_idx,
+        "agent": agent,
+        "phase": phase,
+        "dt_sec": dt_sec,
+        "prompt_full": prompt,
+        "raw_output_full": raw_output,
+    }


### PR DESCRIPTION
### Motivation
- Move debug-record construction and text-hashing/excerpt logic out of the large runner to improve reuse and clarity. 
- Make it easier to support multiple debug output modes (`full` / `compact` / `off`) and an optional separate full-debug JSONL sink. 
- Reduce duplication in `run_simulation.py` and centralize compacting/sha256 logic for consistent behavior.

### Description
- Added a new module `Simulation_robin/debug.py` with `compact_text`, `sha256_text`, `build_debug_record`, and `build_full_debug_record` helpers. 
- Updated `run_simulation.py` to import and use `build_debug_record` and `build_full_debug_record` in `simulate_game` instead of inline helpers, and removed the previous local helper implementations. 
- Plumbed `debug_level` and `debug_full_jsonl_path` through `simulate_game` and `simulate_games`, created per-game full-debug file handling, and extended `simulate_games` return tuple to include the resolved full-debug path. 
- Adjusted CLI handling to support the new `debug_level`, keep backwards compatibility with `debug_compact`, and disable debug sinks when `debug_level` is `off`.

### Testing
- No automated tests were executed on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69738679b16c83319a3e8f78e700e45d)