### PR TITLE
Align prompts with the human PGG interface and persist chat token limit

### DIFF
--- a/Simulation_robin/output_manager.py
+++ b/Simulation_robin/output_manager.py
@@ -57,6 +57,7 @@ def _model_config(args: Any, run_ts: str) -> Dict[str, Any]:
         "top_p",
         "seed",
         "contrib_max_new_tokens",
+        "chat_max_new_tokens",
         "actions_max_new_tokens",
         "include_reasoning",
         "max_parallel_games",

--- a/Simulation_robin/parsers.py
+++ b/Simulation_robin/parsers.py
@@ -80,3 +80,29 @@ def parse_first_int_array(s: str, tag: Optional[str] = None) -> Tuple[Optional[L
             pass
     log(f"[parse] failed to parse array for tag={tag or 'raw'}; defaulting to []")
     return None, False
+
+
+def extract_tag_content(s: str, tag: str) -> Optional[str]:
+    if not isinstance(s, str):
+        return None
+    tagged = extract_answer_tagged(s, tag)
+    if tagged is not None:
+        return tagged
+    pattern = rf"<\s*{re.escape(tag)}\s*>(.*?)</\s*{re.escape(tag)}\s*>"
+    match = re.search(pattern, s, flags=re.DOTALL)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def parse_chat_message(s: str) -> Tuple[str, bool]:
+    if not isinstance(s, str):
+        log("[parse] expected string for chat output; defaulting to silence")
+        return "", False
+    content = extract_tag_content(s, "CHAT")
+    if content is None:
+        return "", False
+    msg = content.strip()
+    if msg in {"", "...", "SILENT", "silence", "NONE", "none"}:
+        return "", True
+    return msg, True

--- a/Simulation_robin/run_simulation.py
+++ b/Simulation_robin/run_simulation.py
@@ -57,6 +57,7 @@ class Args:
     top_p: float = 0.9
     seed: int = 0
     contrib_max_new_tokens: int = 100
+    chat_max_new_tokens: int = 60
     actions_max_new_tokens: int = 100
     include_reasoning: bool = field(
         default=False,


### PR DESCRIPTION
### Motivation
- Make the LLM-facing prompts match the human public-goods game UI (coins, shared pot framing, hidden choices, multiplier, and equal split) while keeping prompts brief and omitting the QA/tutorial parts. 
- Ensure the chat generation token limit is persisted in model metadata so runs record `chat_max_new_tokens` alongside other token limits.

### Description
- Toned and reworded the upfront game text and per-round lines in `Simulation_robin/prompt_builder.py` by updating `game_intro_lines`, `round_info_line`, and `chat_stage_line` to mirror the human interface phrasing and keep stage prompts concise. 
- Changed the system/header behavior to plain-text header lines and ensured format reminders are generated at the end of stage prompts (via the existing `contrib_format_line`, `actions_format_line`, `chat_format_line` primitives). 
- Persisted `chat_max_new_tokens` into model metadata by adding it to `_model_config` in `Simulation_robin/output_manager.py` and added a default `chat_max_new_tokens` arg in the CLI `Args` dataclass in `Simulation_robin/run_simulation.py`. 
- Wired `chat_max_new_tokens` through to `simulate_game` and its batch chat calls, and adjusted transcript construction to include the compact `GAME_INFO` intro block for each participant.

### Testing
- Ran `python -m compileall Simulation_robin`, which completed successfully without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974deb223f0833192956cfde53bf496)