### PR TITLE
Tighten prompts and prevent truncated stage outputs

### DIFF
--- a/Simulation_robin/prompt_builder.py
+++ b/Simulation_robin/prompt_builder.py
@@ -10,6 +10,7 @@ def system_header_lines(env: Dict, include_reasoning: bool) -> List[str]:
     lines.append("You are playing an online public goods game (PGG).")
     lines.append("Follow the stage instructions exactly.")
     lines.append("The required response format will be shown at the END of each prompt.")
+    lines.append("It is valid to stay silent; only speak when it helps your strategy.")
     if include_reasoning:
         lines.append("When asked for reasoning, keep it brief and strategic.")
     if env.get("CONFIG_chat", False):
@@ -77,12 +78,7 @@ def round_info_line(env: Dict) -> str:
 
 
 def chat_stage_line(env: Dict) -> str:
-    endow = int(env.get("CONFIG_endowment", 0) or 0)
-    return (
-        "<CHAT_STAGE> Before contributing, you may send ONE short message to everyone "
-        f"(or stay silent). Keep messages brief (e.g., one sentence). "
-        f"Your contribution will still be an integer from 0 to {endow}. </CHAT_STAGE>"
-    )
+    return "<CHAT_STAGE> Would you like to send a message to the group? You may stay silent. </CHAT_STAGE>"
 
 
 def contrib_open() -> str:


### PR DESCRIPTION
### Motivation
- Reduce agent verbosity and make silence an explicit, valid choice across stages to curb chatty agents.
- Prevent model outputs from being cut mid-tag by increasing generation budgets and fixing stop/closing-bracket handling.
- Ensure game metadata formatting is compact and `# GAME STARTS` appears right before the first round for easier parsing.
- Shorten chat prompts so agents receive a minimal, clear question during the chat stage.

### Description
- Added a global system reminder in `Simulation_robin/prompt_builder.py` that staying silent is valid so all prompts inherit the guidance (`system_header_lines`).
- Replaced the verbose chat-stage text with a concise question in `chat_stage_line`, returning `"<CHAT_STAGE> Would you like to send a message to the group? You may stay silent. </CHAT_STAGE>"`.
- Wrapped the entire intro into a single `<GAME_INFO> ... </GAME_INFO>` block in `simulate_game` and moved `# GAME STARTS` so it is appended only before the first round (both chat and no-chat flows).
- Increased default `max_new_tokens` for `contrib`, `chat`, and `actions` to `12`, `96`, and `192` respectively to reduce truncation risk.
- Removed the hard `stop="]"` for the actions-stage call and instead append a missing closing bracket only when a `[` is present but `]` is not, improving parsing robustness for `PUNISHMENTS/REWARDS` arrays.

### Testing
- Ran `python -m compileall Simulation_robin` successfully to verify the modified modules compile.
- Ran `pytest -q`; collection/run failed in this environment due to a missing external dependency (`edsl`), so full test suite could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974f0f2ce808331abcf11d0520efa2a)