### PR TITLE
Align system prompt with all-or-nothing mode and simplify transcript/output formats

### DIFF
--- a/Simulation_robin/parsers.py
+++ b/Simulation_robin/parsers.py
@@ -27,6 +27,8 @@ def first_int(s: str, tag: Optional[str] = None) -> Tuple[int, bool]:
         tagged = extract_answer_tagged(s, tag)
         if tagged is not None:
             target = tagged
+    if "Answer:" in target:
+        target = target.split("Answer:", 1)[1]
     m = re.search(r"-?\d+", target)
     if not m:
         log(f"[parse] no integer found for tag={tag or 'raw'}; defaulting to 0")
@@ -44,6 +46,8 @@ def parse_first_int_array(s: str, tag: Optional[str] = None) -> Tuple[Optional[L
         tagged = extract_answer_tagged(s, tag)
         if tagged is not None:
             target = tagged
+    if "Answer:" in target:
+        target = target.split("Answer:", 1)[1]
 
     cleaned = target.strip()
     if cleaned.startswith("<<") and ">>" in cleaned:
@@ -101,7 +105,9 @@ def parse_chat_message(s: str) -> Tuple[str, bool]:
         return "", False
     content = extract_tag_content(s, "CHAT")
     if content is None:
-        return "", False
+        content = s
+    if "Answer:" in content:
+        content = content.split("Answer:", 1)[1]
     msg = content.strip()
     if msg in {"", "...", "SILENT", "silence", "NONE", "none"}:
         return "", True


### PR DESCRIPTION
### Motivation
- Fix the system prompt wording so contribution instructions reflect `CONFIG_allOrNothing` and remove the inaccurate broadcast sentence about chat messages.
- Make agent-facing stage instructions and per-stage outputs simpler and machine-friendly to reduce parsing errors and redundant tags.
- Standardize the in-memory transcript format so logs are consistent and easier to serialize/parse downstream.

### Description
- Update `Simulation_robin/prompt_builder.py` to emit a dynamic contribution phrasing (`either 0 or {endow}` when all-or-nothing) and remove the "broadcast" chat sentence, add explicit pot multiplier/payoff lines, and simplify the `FORMAT` strings for contributions, chat, and actions.
- Replace XML/angle-bracket helper output formats with bare values (stringified integer / JSON array) and `Answer:`-prefixed forms only when `include_reasoning` is enabled, and remove unused tag helper functions.
- Modify `Simulation_robin/parsers.py` to tolerate and strip an `Answer:` prefix when parsing integers, integer arrays, and chat messages so both legacy and new agent outputs are accepted.
- Adjust `Simulation_robin/simulator.py` to start transcripts with `# GAME STARTS`, use the full transcript for OpenAI messages, and append simplified transcript lines like `CHAT: ...`, `CONTRIB: ...`, and `{TAG}: <json array>` instead of XML-style tags.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69752053421c8331aa1fb8581c434eb3)