### PR TITLE
Restore Simulation EDSL layout and include FORMAT line in Simulation_robin OpenAI messages

### DIFF
--- a/Simulation_robin/simulator.py
+++ b/Simulation_robin/simulator.py
@@ -151,7 +151,12 @@ def simulate_game(
                 chat_prompt = "\n".join(transcripts[av] + [chat_format_line(include_reasoning)])
                 chat_prompts.append(chat_prompt)
                 chat_meta.append(av)
-                chat_messages_list.append(build_openai_messages(sys_text_plain, transcripts[av]))
+                chat_messages_list.append(
+                    build_openai_messages(
+                        sys_text_plain,
+                        transcripts[av] + [chat_format_line(include_reasoning)],
+                    )
+                )
 
                 if debug_print:
                     if tok is not None:
@@ -239,7 +244,12 @@ def simulate_game(
             prompt = "\n".join(transcripts[av] + [contrib_format_line(include_reasoning)])
             contrib_prompts.append(prompt)
             contrib_meta.append(av)
-            contrib_messages.append(build_openai_messages(sys_text_plain, transcripts[av]))
+            contrib_messages.append(
+                build_openai_messages(
+                    sys_text_plain,
+                    transcripts[av] + [contrib_format_line(include_reasoning)],
+                )
+            )
 
         for av, ptxt in zip(contrib_meta, contrib_prompts):
             if debug_print:
@@ -350,7 +360,12 @@ def simulate_game(
                 prompt = "\n".join(transcripts[av] + [actions_format_line(tag, include_reasoning)])
                 actions_prompts.append(prompt)
                 actions_meta.append(av)
-                actions_messages.append(build_openai_messages(sys_text_plain, transcripts[av]))
+                actions_messages.append(
+                    build_openai_messages(
+                        sys_text_plain,
+                        transcripts[av] + [actions_format_line(tag, include_reasoning)],
+                    )
+                )
                 if debug_print:
                     if tok is not None:
                         tok_len = len(tok(prompt, add_special_tokens=False)["input_ids"])


### PR DESCRIPTION
### Motivation
- Restore the original reasoning prompt layout in `Simulation/edsl_client.py` after the prior change that moved the required output-format block, because that change was applied to the wrong folder. 
- Ensure OpenAI-style message payloads in the `Simulation_robin` runner include the required format line as the last item so model replies follow the expected response format and downstream parsing remains stable.

### Description
- Restored the original ordering of the reasoning/free-text survey in `Simulation/edsl_client.py` so the prior EDSL prompt layout is preserved. 
- Updated `Simulation_robin/simulator.py` so `build_openai_messages(...)` is called with the transcript plus the appropriate format line for each phase, specifically adding `chat_format_line(include_reasoning)` for chat prompts, `contrib_format_line(include_reasoning)` for contribution prompts, and `actions_format_line(tag, include_reasoning)` for action prompts. 
- These changes ensure the required `FORMAT:` hint appears in the OpenAI `messages` payloads (last in the user content) for chat, contribution, and actions phases.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975487a44c48331a3e928531a4e6c15)