### PR TITLE
Increase chat token budget and remove PEER_ORDER transcript comment

### DIFF
--- a/Simulation_robin/run_simulation.py
+++ b/Simulation_robin/run_simulation.py
@@ -57,7 +57,7 @@ class Args:
     top_p: float = 0.9
     seed: int = 0
     contrib_max_new_tokens: int = 100
-    chat_max_new_tokens: int = 60
+    chat_max_new_tokens: int = 96
     actions_max_new_tokens: int = 100
     include_reasoning: bool = field(
         default=False,

--- a/Simulation_robin/simulator.py
+++ b/Simulation_robin/simulator.py
@@ -335,7 +335,6 @@ def simulate_game(
             transcripts[av].append(redist_line(total_contrib, multiplied, active_players))
             peers_csv, peer_order = peers_contributions_csv(roster, av, contrib_math)
             transcripts[av].append(f"<PEERS_CONTRIBUTIONS> {peers_csv} </PEERS_CONTRIBUTIONS>")
-            transcripts[av].append(f"<!-- PEER_ORDER {json.dumps(peer_order)} -->")
 
         reward_on = env.get("CONFIG_rewardExists", False)
         punish_on = env.get("CONFIG_punishmentExists", False)


### PR DESCRIPTION
### Motivation
- Increase the default `chat_max_new_tokens` to reduce output truncation and remove the now-obsolete `PEER_ORDER` transcript annotation since actions are emitted as dicts.

### Description
- Change `chat_max_new_tokens` in `Simulation_robin/run_simulation.py` from `60` to `96` and delete the commented `<!-- PEER_ORDER ... -->` line in `Simulation_robin/simulator.py` where peer contributions are recorded.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69754e5f4aa48331add003620815589c)