### PR TITLE
Use full deduped env CSV by default

### DIFF
--- a/Simulation_robin/run_simulation.py
+++ b/Simulation_robin/run_simulation.py
@@ -36,7 +36,7 @@ class Args:
     adapter_path: Optional[str] = field(default="out/llama31-8b-lora-pgg-ptc/checkpoint-489")
     use_peft: bool = field(default=True)
 
-    env_csv: str = field(default="df_analysis_val.csv")
+    env_csv: str = field(default="../data/processed_data/df_analysis_val.csv")
     output_root: str = field(
         default="output",
         metadata={"help": "Base output directory to store experiment/timestamp folders."},
@@ -106,7 +106,7 @@ def main(args: CLIArgs):
         log(f"[env] dedup by name: {before} -> {len(env_df)} rows")
 
     df_all, transcripts_all, output_paths = simulate_games(
-        env_df=env_df.iloc[:40],
+        env_df=env_df,
         args=args,
     )
 


### PR DESCRIPTION
### Motivation
- The default env CSV path and a hard 40-row cap were incorrect for typical runs, so the CLI should point to the processed data file and simulate all deduplicated rows by default.

### Description
- Change the `env_csv` default to `../data/processed_data/df_analysis_val.csv` and remove the `env_df.iloc[:40]` slice so `simulate_games` receives the full deduped `env_df`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69737b0a660c8331aee1244ad93fc4c6)