### PR TITLE
Support stop sequence lists in local LLM generation

### DIFF
--- a/Simulation_robin/simulator.py
+++ b/Simulation_robin/simulator.py
@@ -183,7 +183,7 @@ def simulate_game(
             chat_raw = client.generate_batch(
                 prompts=chat_prompts,
                 messages_list=chat_messages_list,
-                stop=None,
+                stop=["</CHAT>"],
                 max_new_tokens=chat_max_new_tokens,
                 temperature=temperature,
                 top_p=top_p,
@@ -287,7 +287,7 @@ def simulate_game(
         contrib_raw = client.generate_batch(
             prompts=contrib_prompts,
             messages_list=contrib_messages,
-            stop=None,
+            stop=["</CONTRIB>"],
             max_new_tokens=contrib_max_new_tokens,
             temperature=temperature,
             top_p=top_p,
@@ -410,7 +410,7 @@ def simulate_game(
             actions_raw = client.generate_batch(
                 prompts=actions_prompts,
                 messages_list=actions_messages,
-                stop=None,
+                stop=[f"</{tag}>"],
                 max_new_tokens=actions_max_new_tokens,
                 temperature=temperature,
                 top_p=top_p,


### PR DESCRIPTION
### Motivation
- Local model generation needs to stop when any of several closing tags appears so downstream parsers reliably see complete closing tags (e.g., `</CONTRIB>`, `</CHAT>`, `</PUNISHMENT>`, etc.).

### Description
- Add `_apply_stop_sequences(text, stop: Optional[List[str]])` that truncates after the earliest stop sequence and preserves the stop token in the returned text.
- Update `_batch_generate_until` to accept `stop: Optional[List[str]]`, add a `StoppingCriteria` (`_StopOnSequences`) for the transformers `generate` call that halts when any stop string appears in the decoded buffer, and apply `_apply_stop_sequences` to the decoded outputs.
- Update `LLMClient._openai_chat_completion` and `LLMClient.generate_batch` signatures to accept `stop: Optional[List[str]]` and reuse the list-based stop handling for OpenAI responses.
- Modify `simulate_game` calls in `Simulation_robin/simulator.py` to pass phase-specific stop lists: `[

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69766d4be05c83319e1e56241ea0a298)