### PR TITLE
Add `YOUR RESPONSE` marker and ensure `<Reasoning>` remains last; move max-tokens reminder before format

### DIFF
--- a/Simulation_robin/prompt_builder.py
+++ b/Simulation_robin/prompt_builder.py
@@ -87,8 +87,8 @@ def format_contrib_answer(val) -> str:
 
 def contrib_format_line(include_reasoning: bool) -> str:
     if include_reasoning:
-        return "FORMAT: <Reasoning>...</Reasoning> <CONTRIB> <integer> </CONTRIB>"
-    return "FORMAT: <CONTRIB> <integer> </CONTRIB>"
+        return "FORMAT: <Reasoning>...</Reasoning> <CONTRIB> <integer> </CONTRIB>\nYOUR RESPONSE:\n<Reasoning>"
+    return "FORMAT: <CONTRIB> <integer> </CONTRIB>\nYOUR RESPONSE:"
 
 
 def actions_format_line(tag: str, include_reasoning: bool) -> str:
@@ -99,14 +99,14 @@ def actions_format_line(tag: str, include_reasoning: bool) -> str:
     else:
         dict_hint = "Use a dict mapping avatar -> integer units; omit zeros. Negative=punishment, positive=reward."
     if include_reasoning:
-        return f"FORMAT: <Reasoning>...</Reasoning> <{tag}> {{dict}} </{tag}> ({dict_hint})"
-    return f"FORMAT: <{tag}> {{dict}} </{tag}> ({dict_hint})"
+        return f"FORMAT: <Reasoning>...</Reasoning> <{tag}> {{dict}} </{tag}> ({dict_hint})\nYOUR RESPONSE:\n<Reasoning>"
+    return f"FORMAT: <{tag}> {{dict}} </{tag}> ({dict_hint})\nYOUR RESPONSE:"
 
 
 def chat_format_line(include_reasoning: bool) -> str:
     if include_reasoning:
-        return "FORMAT: <Reasoning>...</Reasoning> then (optional) <CHAT>...</CHAT>. If silent, omit <CHAT>."
-    return "FORMAT: Output <CHAT>...</CHAT> or empty string if silent."
+        return "FORMAT: <Reasoning>...</Reasoning> then (optional) <CHAT>...</CHAT>. If silent, omit <CHAT>.\nYOUR RESPONSE:\n<Reasoning>"
+    return "FORMAT: Output <CHAT>...</CHAT> or empty string if silent.\nYOUR RESPONSE:"
 
 
 def max_tokens_reminder_line(max_tokens: int) -> str:

--- a/Simulation_robin/simulator.py
+++ b/Simulation_robin/simulator.py
@@ -151,8 +151,8 @@ def simulate_game(
                 transcripts[av].append(chat_stage_line(env))
 
                 chat_chunks = transcripts[av] + [
-                    chat_format_line(include_reasoning),
                     max_tokens_reminder_line(chat_max_new_tokens),
+                    chat_format_line(include_reasoning),
                 ]
                 if include_system_in_prompt:
                     chat_chunks = [sys_text_plain] + chat_chunks
@@ -164,8 +164,8 @@ def simulate_game(
                         sys_text_plain,
                         transcripts[av]
                         + [
-                            chat_format_line(include_reasoning),
                             max_tokens_reminder_line(chat_max_new_tokens),
+                            chat_format_line(include_reasoning),
                         ],
                     )
                 )
@@ -254,8 +254,8 @@ def simulate_game(
         contrib_messages: List[List[Dict[str, str]]] = []
         for av in roster:
             contrib_chunks = transcripts[av] + [
-                contrib_format_line(include_reasoning),
                 max_tokens_reminder_line(contrib_max_new_tokens),
+                contrib_format_line(include_reasoning),
             ]
             if include_system_in_prompt:
                 contrib_chunks = [sys_text_plain] + contrib_chunks
@@ -267,8 +267,8 @@ def simulate_game(
                     sys_text_plain,
                     transcripts[av]
                     + [
-                        contrib_format_line(include_reasoning),
                         max_tokens_reminder_line(contrib_max_new_tokens),
+                        contrib_format_line(include_reasoning),
                     ],
                 )
             )
@@ -379,8 +379,8 @@ def simulate_game(
                     transcripts[av].append(f"<MECHANISM_INFO> {mech} </MECHANISM_INFO>")
 
                 actions_chunks = transcripts[av] + [
-                    actions_format_line(tag, include_reasoning),
                     max_tokens_reminder_line(actions_max_new_tokens),
+                    actions_format_line(tag, include_reasoning),
                 ]
                 if include_system_in_prompt:
                     actions_chunks = [sys_text_plain] + actions_chunks
@@ -392,8 +392,8 @@ def simulate_game(
                         sys_text_plain,
                         transcripts[av]
                         + [
-                            actions_format_line(tag, include_reasoning),
                             max_tokens_reminder_line(actions_max_new_tokens),
+                            actions_format_line(tag, include_reasoning),
                         ],
                     )
                 )


### PR DESCRIPTION
### Motivation
- Make the expected output block in prompts clearer to human readers and models by adding an explicit `YOUR RESPONSE:` indicator before the response area.
- Ensure that when reasoning is requested the opening `<Reasoning>` tag is the final line of the prompt so the parser sees the expected `<Reasoning>...</Reasoning>` pattern.
- Prevent the `MAX_TOKENS` reminder from appearing after the reasoning marker by moving it earlier in prompt assembly.

### Description
- Updated `Simulation_robin/prompt_builder.py` to add `YOUR RESPONSE:` to the strings returned by `contrib_format_line`, `actions_format_line`, and `chat_format_line`, and kept the `\n<Reasoning>` line as the final line when `include_reasoning=True`.
- Kept `max_tokens_reminder_line` unchanged and formatted the format strings so `YOUR RESPONSE:` precedes the optional `<Reasoning>` block when reasoning is enabled.
- Reordered prompt assembly in `Simulation_robin/simulator.py` so `max_tokens_reminder_line(...)` is inserted before the corresponding format line for chat, contrib, and actions prompts and in the `build_openai_messages` message lists, ensuring the format/response block remains last in the assembled prompt.
- Touched prompt construction in three places: the `chat` block, the `contrib` block, and the `actions` block.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69766e2a211083319bc3d9da49635016)