### PR TITLE
Add per-player avatar reminder to transcripts

### DIFF
--- a/Simulation_robin/simulator.py
+++ b/Simulation_robin/simulator.py
@@ -105,6 +105,7 @@ def simulate_game(
 
     for av in roster:
         transcripts[av] = ["# GAME STARTS"]
+        transcripts[av].append(f"You will refer to each other by their avatar. Your avatar is {av}.")
 
     csv_writer = None
     csv_file = None


### PR DESCRIPTION
### Motivation
- Ensure each player's prompt context includes a per-player system line identifying the player's avatar so models consistently refer to peers by avatar.

### Description
- Append a per-player line to `transcripts[av]` immediately after `transcripts[av] = ["# GAME STARTS"]` in `Simulation_robin/simulator.py` that reads `You will refer to each other by their avatar. Your avatar is {av}.`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69766f6713c0833193f8d4206bba6037)