### PR TITLE
Refine JSON prompt guidance and opt-out contribution wording

### DIFF
--- a/Simulation_robin/parsers.py
+++ b/Simulation_robin/parsers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import ast
 import json
 import re
-from typing import List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from utils import log
 
@@ -126,4 +126,34 @@ def parse_int_dict(s: str, tag: str) -> Tuple[Optional[dict], bool]:
         except Exception:
             continue
     log(f"[parse] failed to parse dict for tag={tag}; defaulting to {{}}")
+    return None, False
+
+
+def parse_json_response(s: str) -> Tuple[Optional[Dict[str, Any]], bool]:
+    if not isinstance(s, str):
+        log("[parse] expected string for JSON output; defaulting to None")
+        return None, False
+    cleaned = s.strip()
+    if cleaned.startswith("```"):
+        cleaned = cleaned.strip("`")
+    try:
+        obj = json.loads(cleaned)
+        if isinstance(obj, dict):
+            return obj, True
+    except Exception:
+        pass
+    if "{" not in cleaned or "}" not in cleaned:
+        log("[parse] no JSON object found; defaulting to None")
+        return None, False
+    start = cleaned.find("{")
+    end = cleaned.rfind("}")
+    snippet = cleaned[start : end + 1]
+    try:
+        obj = json.loads(snippet)
+        if isinstance(obj, dict):
+            return obj, True
+    except Exception:
+        log("[parse] failed to parse JSON object; defaulting to None")
+        return None, False
+    log("[parse] invalid JSON output; defaulting to None")
     return None, False


### PR DESCRIPTION
### Motivation
- Enforce fully structured, JSON-only agent responses and remove legacy free-text reasoning/stage guidance to simplify parsing. 
- Make the chat silence instruction local to the chat phase so other stages do not imply optional silence. 
- Clarify opt-out/opt-in contribution behavior by treating `CONFIG_defaultContribProp` as a float and reword the pot/withdrawal prompt to be easier for models to follow. 

### Description
- Updated `Simulation_robin/prompt_builder.py` to remove legacy lines (`Follow the stage instructions exactly.` and the old reasoning guidance), require JSON-only formats for `chat`, `contribution`, and `actions`, move the “stay silent” guidance into the chat-format prompt, and reword the round info to: "Choose how many coins to leave in the pot for contribution.".
- Changed handling of `CONFIG_defaultContribProp` to test `float(env.get("CONFIG_defaultContribProp", 0.0) or 0.0) > 0.0` so the float-based opt-in/opt-out semantics behave consistently.
- Added `parse_json_response` to `Simulation_robin/parsers.py` to robustly extract a JSON object from LLM output (handles fenced code blocks and substring extraction) and updated imports accordingly.
- Modified `Simulation_robin/simulator.py` to use `parse_json_response` for `chat`, `contrib`, and `actions` phases, to extract `stage`/`reasoning`/payload fields safely, to fall back on defaults when parsing fails, and to stop relying on hard stop tokens by using `stop=None`.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976a750486883319d67f9db3498af94)