### PR TITLE
Handle Windows newlines in stop sequences and refine prompt templates

### DIFF
--- a/Simulation_robin/prompt_builder.py
+++ b/Simulation_robin/prompt_builder.py
@@ -84,15 +84,15 @@ def format_contrib_answer(val) -> str:
 def contrib_format_line(env: Dict, include_reasoning: bool) -> str:
     contrib_hint = "Set 'contribution' to the amount left in the pot (your contribution)."
     if include_reasoning:
-        reasoning_hint = "Include a short 'reasoning' string."
+        reasoning_hint = "Provide reasons for your action, keep it brief."
         fmt = '{"stage":"contribution","reasoning":<string>,"contribution":<int>}'
     else:
         reasoning_hint = "Do not include a 'reasoning' field."
         fmt = '{"stage":"contribution","contribution":<int>}'
     return (
+        f"RULES: {contrib_hint} {reasoning_hint}\n"
         "FORMAT (JSON ONLY): "
         f"{fmt}\n"
-        f"RULES: {contrib_hint} {reasoning_hint}\n"
         "YOUR RESPONSE:"
     )
 
@@ -108,31 +108,31 @@ def actions_format_line(tag: str, include_reasoning: bool) -> str:
             "Negative=punishment, positive=reward."
         )
     if include_reasoning:
-        reasoning_hint = "Include a short 'reasoning' string."
+        reasoning_hint = "Provide reasons for your action, keep it brief."
         fmt = '{"stage":"actions","reasoning":<string>,"actions":{...}}'
     else:
         reasoning_hint = "Do not include a 'reasoning' field."
         fmt = '{"stage":"actions","actions":{...}}'
     return (
+        f"RULES: {dict_hint} {reasoning_hint}\n"
         "FORMAT (JSON ONLY): "
         f"{fmt}\n"
-        f"RULES: {dict_hint} {reasoning_hint}\n"
         "YOUR RESPONSE:"
     )
 
 
 def chat_format_line(include_reasoning: bool) -> str:
     if include_reasoning:
-        reasoning_hint = "Include a short 'reasoning' string."
+        reasoning_hint = "Provide reasons for your action, keep it brief."
         fmt = '{"stage":"chat","reasoning":<string>,"chat":<string|null>}'
     else:
         reasoning_hint = "Do not include a 'reasoning' field."
         fmt = '{"stage":"chat","chat":<string|null>}'
     return (
+        "RULES: Set 'chat' to a short message, or null/empty string if silent. Speak only when it helps. "
+        f"{reasoning_hint}\n"
         "FORMAT (JSON ONLY): "
         f"{fmt}\n"
-        "RULES: Set 'chat' to a short message, or null/empty string if silent. It is valid to stay silent. "
-        f"{reasoning_hint}\n"
         "YOUR RESPONSE:"
     )
 

--- a/Simulation_robin/simulator.py
+++ b/Simulation_robin/simulator.py
@@ -91,7 +91,7 @@ def simulate_game(
     debug_records: List[Dict[str, Any]] = []
     debug_full_records: List[Dict[str, Any]] = []
     debug_excerpt_chars = 200
-    stop_sequences = ["\n"]
+    stop_sequences = ["\n\n", "\r\n\r\n"]
 
     roster = sample_roster(env, seed=seed)
     assert len(roster) == env["CONFIG_playerCount"], "Roster length must match ENV.players"


### PR DESCRIPTION
### Motivation
- Model outputs were being truncated by an overly-aggressive single-newline stop and earlier change to a POSIX double-newline stop still missed Windows-style newlines. 
- Prompt templates needed clearer ordering and phrasing to make JSON-only responses and brief reasoning instructions more robust and consistent.

### Description
- Broadened the stop sequences in `Simulation_robin/simulator.py` to `["\n\n", "\r\n\r\n"]` to catch both POSIX and Windows double-newline boundaries. 
- Reordered prompt fragments so `RULES` precede `FORMAT` in `Simulation_robin/prompt_builder.py` to emphasize behavioral constraints before the JSON schema. 
- Replaced `"Include a short 'reasoning' string."` with `"Provide reasons for your action, keep it brief."` across contribution, actions, and chat templates. 
- Changed the chat guidance from `"It is valid to stay silent."` to `"Speak only when it helps."` and adjusted the chat `RULES` wording to encourage concise messages or explicit silence.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976bd3950d48331abd7eb0daf514ecb)