### PR TITLE
Refine prompt questions, keep them out of transcripts, and quiet debug logs by default

### DIFF
--- a/Simulation_robin/prompt_builder.py
+++ b/Simulation_robin/prompt_builder.py
@@ -28,7 +28,10 @@ def system_header_lines(env: Dict, include_reasoning: bool) -> List[str]:
         lines.append("After contributions are redistributed, players may punish each other.")
     elif reward_on:
         lines.append("After contributions are redistributed, players may reward each other.")
-    lines.append("Always respond with ONLY valid single-line JSON per the required format at the END of each prompt.")
+    lines.append(
+        "Always respond with ONLY one valid single-line JSON object matching the required format. "
+        "Do not add extra text before or after the JSON; stop immediately after the closing brace."
+    )
     if env.get("CONFIG_chat", False):
         lines.append("At the start of each round, you may optionally send ONE short message to the group.")
     return lines
@@ -64,16 +67,16 @@ def round_info_line(env: Dict) -> str:
     if float(env.get("CONFIG_defaultContribProp", 0.0) or 0.0) > 0.0:
         pre = (
             f"{endow} coins start in the shared pot and you can choose to take some for yourself. "
-            f"Choose how many coins to leave in the pot for contribution. Valid choice: {contrib_mode}."
+            f"How many coins would you like to leave in the pot ({contrib_mode})?"
         )
     else:
-        pre = f"You have {endow} coins in your pocket. Choose how many to contribute to the shared pot ({contrib_mode})."
+        pre = f"You have {endow} coins in your pocket. How much would you like to contribute ({contrib_mode})?"
     mult = env.get("CONFIG_multiplier", "Unknown")
-    return f"<ROUND_INFO> {pre} The pot multiplier is {mult}×. </ROUND_INFO>"
+    return f"QUESTION: {pre} The pot multiplier is {mult}×."
 
 
 def chat_stage_line(env: Dict) -> str:
-    return "<CHAT_STAGE> Would you like to send a message to the group? You may stay silent. Speak only when it helps. </CHAT_STAGE>"
+    return "QUESTION: Would you like to send a message to the group? You may stay silent. Speak only when it helps."
 
 
 def format_contrib_answer(val) -> str:
@@ -90,10 +93,11 @@ def contrib_format_line(env: Dict, include_reasoning: bool) -> str:
         reasoning_hint = ""
         fmt = '{"stage":"contribution","contribution":<int>}'
     return (
+        "QUESTION: Provide ONLY the JSON object for stage 'contribution'. Do not add extra text.\n"
         f"RULES: {contrib_hint} {reasoning_hint}\n"
         "FORMAT (JSON ONLY): "
         f"{fmt}\n"
-        "YOUR RESPONSE:"
+        "YOUR RESPONSE (single-line JSON only):"
     )
 
 
@@ -114,10 +118,11 @@ def actions_format_line(tag: str, include_reasoning: bool) -> str:
         reasoning_hint = ""
         fmt = '{"stage":"actions","actions":{...}}'
     return (
+        "QUESTION: Provide ONLY the JSON object for stage 'actions'. Do not add extra text.\n"
         f"RULES: {dict_hint} {reasoning_hint}\n"
         "FORMAT (JSON ONLY): "
         f"{fmt}\n"
-        "YOUR RESPONSE:"
+        "YOUR RESPONSE (single-line JSON only):"
     )
 
 
@@ -129,11 +134,12 @@ def chat_format_line(include_reasoning: bool) -> str:
         reasoning_hint = ""
         fmt = '{"stage":"chat","chat":<string|null>}'
     return (
+        "QUESTION: Provide ONLY the JSON object for stage 'chat'. Do not add extra text.\n"
         "RULES: Set 'chat' to a short message, or null/empty string if silent. "
         f"{reasoning_hint}\n"
         "FORMAT (JSON ONLY): "
         f"{fmt}\n"
-        "YOUR RESPONSE:"
+        "YOUR RESPONSE (single-line JSON only):"
     )
 
 
@@ -173,18 +179,22 @@ def mech_info(env: Dict) -> Optional[str]:
         return None
     if r_on and p_on:
         return (
-            f"It will cost you, per reward unit, {env['CONFIG_rewardCost']} coins to give a reward of {env['CONFIG_rewardMagnitude']} coins. "
-            f"It will cost you, per punishment unit, {env['CONFIG_punishmentCost']} coins to impose a deduction of {env['CONFIG_punishmentMagnitude']} coins. "
-            "Choose whom to punish/reward and by how many units."
+            "QUESTION: It will cost you, per reward unit, "
+            f"{env['CONFIG_rewardCost']} coins to give a reward of {env['CONFIG_rewardMagnitude']} coins. "
+            f"It will cost you, per punishment unit, {env['CONFIG_punishmentCost']} coins to impose a deduction "
+            f"of {env['CONFIG_punishmentMagnitude']} coins. "
+            "Who would you like to punish or reward, and by how many units?"
         )
     if r_on:
         return (
-            f"It will cost you, per unit, {env['CONFIG_rewardCost']} coins to give a reward of {env['CONFIG_rewardMagnitude']} coins. "
-            "Choose whom to reward and by how many units."
+            "QUESTION: It will cost you, per unit, "
+            f"{env['CONFIG_rewardCost']} coins to give a reward of {env['CONFIG_rewardMagnitude']} coins. "
+            "Who would you like to reward and by how many units?"
         )
     return (
-        f"It will cost you, per unit, {env['CONFIG_punishmentCost']} coins to impose a deduction of {env['CONFIG_punishmentMagnitude']} coins. "
-        "Choose whom to punish and by how many units."
+        "QUESTION: It will cost you, per unit, "
+        f"{env['CONFIG_punishmentCost']} coins to impose a deduction of {env['CONFIG_punishmentMagnitude']} coins. "
+        "Who would you like to punish and by how many units?"
     )
 
 

--- a/Simulation_robin/run_simulation.py
+++ b/Simulation_robin/run_simulation.py
@@ -66,7 +66,7 @@ class Args:
         metadata={"help": "If true, request a short Reasoning line followed by a strict Answer line."},
     )
 
-    debug_print: bool = True
+    debug_print: bool = False
     debug_level: str = field(
         default="full",
         metadata={"help": "Debug output level: full | compact | off"},
@@ -91,7 +91,8 @@ class CLIArgs(Args):
 
 
 def main(args: CLIArgs):
-    log(args)
+    if args.debug_print:
+        log(args)
     if args.debug_compact:
         args.debug_level = "compact"
     if args.debug_level not in {"full", "compact", "off"}:
@@ -105,23 +106,25 @@ def main(args: CLIArgs):
     if "name" in env_df.columns:
         before = len(env_df)
         env_df = env_df.drop_duplicates(subset="name", keep="first")
-        log(f"[env] dedup by name: {before} -> {len(env_df)} rows")
+        if args.debug_print:
+            log(f"[env] dedup by name: {before} -> {len(env_df)} rows")
 
     df_all, transcripts_all, output_paths = simulate_games(
         env_df=env_df,
         args=args,
     )
 
-    log(f"[ptc] simulated rows: {len(df_all)} across {len(transcripts_all)} experiments")
-    for game_id, paths in output_paths.items():
-        log(f"[ptc] outputs for {game_id} → {paths.get('directory')}")
-        log(f"[ptc]   rows: {paths.get('rows')}")
-        log(f"[ptc]   transcripts: {paths.get('transcripts')}")
-        if paths.get("debug"):
-            log(f"[ptc]   debug: {paths.get('debug')}")
-        if paths.get("debug_full") and args.debug_level != "off":
-            log(f"[ptc]   debug_full: {paths.get('debug_full')}")
-        log(f"[ptc]   config: {paths.get('config')}")
+    if args.debug_print:
+        log(f"[ptc] simulated rows: {len(df_all)} across {len(transcripts_all)} experiments")
+        for game_id, paths in output_paths.items():
+            log(f"[ptc] outputs for {game_id} → {paths.get('directory')}")
+            log(f"[ptc]   rows: {paths.get('rows')}")
+            log(f"[ptc]   transcripts: {paths.get('transcripts')}")
+            if paths.get("debug"):
+                log(f"[ptc]   debug: {paths.get('debug')}")
+            if paths.get("debug_full") and args.debug_level != "off":
+                log(f"[ptc]   debug_full: {paths.get('debug_full')}")
+            log(f"[ptc]   config: {paths.get('config')}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Make prompts explicitly ask the user with `QUESTION:` lines (per-stage `chat`, `contribution`, and mechanism prompts) and ensure agents return a single-line JSON object only. 
- Keep transcripts compact and focused on results by avoiding insertion of prompt `QUESTION:` text into the saved transcripts. 
- Reduce noisy console output by disabling verbose printing by default while keeping full debug capture available.

### Description
- Updated `Simulation_robin/prompt_builder.py` to: enforce the single-line JSON requirement in the system header, convert `round_info_line`, `chat_stage_line`, and `mech_info` to explicit `QUESTION:` phrasing, and reorder stage prompt blocks so the `QUESTION:` appears and stage `FORMAT`/`RULES`/`YOUR RESPONSE (single-line JSON only)` guidance are clear. 
- Updated `Simulation_robin/simulator.py` to stop inserting `QUESTION:` prompt lines into transcripts (they are now only added to the model prompt), to assemble per-focal-player compact `CHAT_TRANSCRIPT` blocks with the focal player labeled `'(YOU)'`, and to append `mech` only to the prompt assembly (not the transcript) while fixing how action prompt chunks are built. 
- Updated `Simulation_robin/run_simulation.py` to set `debug_print` default to `False` and `debug_level` default to `full`, and to gate per-game and env deduplication logging behind `args.debug_print` so console output is quiet unless explicitly requested. 
- Changes touch three files: `Simulation_robin/prompt_builder.py`, `Simulation_robin/simulator.py`, and `Simulation_robin/run_simulation.py` and adjust prompt wording, prompt assembly, and logging behavior.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976cad391288331b301e2a439c0ad5b)