### PR TITLE
Simplify transcript phrasing for chat, contributions, and actions

### DIFF
--- a/Simulation_robin/prompt_builder.py
+++ b/Simulation_robin/prompt_builder.py
@@ -81,7 +81,7 @@ def chat_stage_line(env: Dict) -> str:
 
 def format_contrib_answer(val) -> str:
     base = str(val)
-    return f"<CONTRIB> {base} </CONTRIB>"
+    return f"You contributed: {base}"
 
 
 def contrib_format_line(env: Dict, include_reasoning: bool) -> str:
@@ -210,4 +210,4 @@ def actions_tag(env: Dict) -> Optional[str]:
 
 def format_actions_answer(tag: str, actions: Dict[str, int]) -> str:
     base = json.dumps(actions, separators=(",", ":"))
-    return f"<{tag}> {base} </{tag}>"
+    return f"You took actions: {base}"


### PR DESCRIPTION
### Motivation
- Make agent transcript entries easier for humans to read by switching XML-like tags to plain-language lines for reasoning, chat logs, contributions, and action outcomes.
- Provide explicit, user-facing summaries for punishment/reward phases so it’s clear when an agent took no action.
- Preserve structured data where downstream parsing is needed while improving readability of common transcript lines.

### Description
- Replaced XML-styled contribution output with a plain text line by changing `format_contrib_answer` to return `You contributed: <value>`.
- Reworked action-phase output so `simulator.py` emits explicit plain-language summaries (e.g., `You punished: {...}`, `You rewarded: {...}`, or `You did not ... anybody.`) instead of embedding actions in an XML tag.
- Replaced `<Reasoning>...</Reasoning>` lines with `You thought: ...` for chat, contribution, and action reasoning, and converted chat transcripts from `<CHAT_TRANSCRIPT>...` to a `CHAT:` bullet list format.
- Adjusted imports to remove the now-unused `format_actions_answer` and fixed an indentation placement of the actions reasoning append.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976d752696483319c881edd8f6b3370)