### PR TITLE
Retry local generation on CUDA OOM by chunking and clearing cache

### DIFF
--- a/Simulation_robin/llm_client.py
+++ b/Simulation_robin/llm_client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import warnings
 from typing import Any, Dict, List, Optional
 
 import asyncio
@@ -219,13 +220,33 @@ class LLMClient:
             return asyncio.run(_run_async())
         if prompts is None or self.tok is None or self.model is None:
             raise ValueError("Local provider requires prompts and a loaded model/tokenizer.")
-        return _batch_generate_until(
-            self.tok,
-            self.model,
-            prompts,
-            stop=stop,
-            max_new_tokens=max_new_tokens,
-            temperature=temperature,
-            top_p=top_p,
-            seed=seed,
-        )
+        chunk_size = len(prompts)
+        while True:
+            try:
+                outputs: List[str] = []
+                for start in range(0, len(prompts), chunk_size):
+                    chunk_prompts = prompts[start : start + chunk_size]
+                    outputs.extend(
+                        _batch_generate_until(
+                            self.tok,
+                            self.model,
+                            chunk_prompts,
+                            stop=stop,
+                            max_new_tokens=max_new_tokens,
+                            temperature=temperature,
+                            top_p=top_p,
+                            seed=seed,
+                        )
+                    )
+                return outputs
+            except torch.OutOfMemoryError as exc:
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+                if chunk_size <= 1:
+                    raise exc
+                reduced_size = max(1, chunk_size // 2)
+                warnings.warn(
+                    "CUDA OOM during generation with batch size "
+                    f"{chunk_size}; retrying with reduced chunk size {reduced_size}."
+                )
+                chunk_size = reduced_size


### PR DESCRIPTION
### Motivation
- Prevent local `model.generate` runs from failing hard when GPU memory is fragmented or insufficient by making batch generation resilient to OOMs. 
- Provide a clear runtime signal when the batch size is auto-reduced so downstream users know the client adjusted to memory limits.

### Description
- Added `warnings` import and updated `LLMClient.generate_batch` (local path `Simulation_robin/llm_client.py`) to perform chunked generation when `provider=='local'`. 
- Wraps generation in a loop that splits `prompts` into `chunk_size` and on `torch.OutOfMemoryError` calls `torch.cuda.empty_cache()`, halves `chunk_size` (down to `1`), and retries. 
- Emits a `warnings.warn` containing the original chunk size and the reduced chunk size when recovering from OOM.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b879e851c8331972e358080bcf9af)