### PR TITLE
Plot RMSE: per-metric config subplots and aggregate RMSE with human-std noise ceiling

### DIFF
--- a/Analysis_robin/analyze.py
+++ b/Analysis_robin/analyze.py
@@ -27,7 +27,7 @@ from .config import (
     DEFAULT_OUTPUT_ROOT,
 )
 from .io_utils import load_human_rows, load_simulation_runs
-from .plotting import plot_config_metric_errors, plot_noise_ceiling
+from .plotting import plot_aggregate_metric_rmse, plot_config_metric_rmse
 
 
 def _timestamp() -> str:
@@ -120,8 +120,8 @@ def main() -> None:
         output_dir / "alignment_config_metric_summary.csv", config_metric_summaries
     )
 
-    plot_noise_ceiling(output_dir, alignment_rows)
-    plot_config_metric_errors(output_dir, config_metric_summaries)
+    plot_config_metric_rmse(output_dir, config_metric_summaries)
+    plot_aggregate_metric_rmse(output_dir, config_metric_summaries)
 
     manifest = {
         "timestamp": timestamp,
@@ -131,8 +131,8 @@ def main() -> None:
         "human_configs": str(args.human_configs),
         "metrics": metrics,
         "notes": (
-            "Noise ceiling plotted as ±1 SEM of human game-level means. "
-            "Config-level error plots use mean human variance as the noise ceiling."
+            "RMSE plotted with human standard deviation as the noise ceiling. "
+            "Aggregate RMSE uses bootstrap standard deviation across configs for error bars."
         ),
     }
     with (output_dir / "manifest.json").open("w", encoding="utf-8") as handle:

--- a/Analysis_robin/plotting.py
+++ b/Analysis_robin/plotting.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List
+from typing import Dict, List, Tuple
 
-from .comparison import AlignmentRow, ConfigMetricSummary
+from .comparison import ConfigMetricSummary
 
 
 def _simplify_label(config_name: str) -> str:
@@ -12,50 +12,17 @@ def _simplify_label(config_name: str) -> str:
     return config_name
 
 
-def plot_noise_ceiling(output_dir: Path, alignment_rows: List[AlignmentRow]) -> List[Path]:
-    try:
-        import matplotlib.pyplot as plt
-    except ImportError:
-        return []
-
-    paths: List[Path] = []
-    metrics = sorted({row.metric for row in alignment_rows})
-    for metric in metrics:
-        rows = [row for row in alignment_rows if row.metric == metric]
-        if not rows:
-            continue
-        labels = [_simplify_label(row.config) for row in rows]
-        sim_values = [row.sim_mean for row in rows]
-        human_values = [row.human_mean for row in rows]
-        noise = [row.human_sem for row in rows]
-
-        fig, ax = plt.subplots(figsize=(10, 5))
-        x = list(range(len(labels)))
-        ax.errorbar(
-            x,
-            human_values,
-            yerr=noise,
-            fmt="o",
-            linestyle="none",
-            capsize=3,
-            label="Human mean (±1 SEM)",
-        )
-        ax.scatter(x, sim_values, marker="x", label="Simulation mean")
-        ax.set_xticks(x)
-        ax.set_xticklabels(labels, rotation=45, ha="right")
-        ax.set_title(f"{metric}: simulation vs human with noise ceiling")
-        ax.legend()
-        ax.set_ylabel(metric)
-        fig.tight_layout()
-
-        output_path = output_dir / f"noise_ceiling_{metric}.png"
-        fig.savefig(output_path)
-        plt.close(fig)
-        paths.append(output_path)
-    return paths
+def _metric_titles() -> Dict[str, str]:
+    return {
+        "mean_contribution_rate": "Contribution rate",
+        "normalized_efficiency": "Normalized efficiency",
+        "mean_payoff": "Payoff",
+        "punishment_rate": "Punishment rate",
+        "reward_rate": "Reward rate",
+    }
 
 
-def plot_config_metric_errors(
+def plot_config_metric_rmse(
     output_dir: Path, rows: List[ConfigMetricSummary]
 ) -> List[Path]:
     try:
@@ -67,30 +34,125 @@ def plot_config_metric_errors(
     if not rows:
         return paths
 
-    rows = sorted(rows, key=lambda row: row.config)
-    labels = [_simplify_label(row.config) for row in rows]
-    metrics = [
-        ("rmse", "RMSE"),
-        ("mae", "MAE"),
-        ("r2", "R²"),
-    ]
-    x = list(range(len(labels)))
-    width = 0.4
-    for key, title in metrics:
-        values = [getattr(row, key) for row in rows]
-        noise = [row.noise_ceiling for row in rows]
-        fig, ax = plt.subplots(figsize=(10, 5))
-        ax.bar([i - width / 2 for i in x], values, width=width, label=title)
-        ax.bar([i + width / 2 for i in x], noise, width=width, label="Noise ceiling")
+    metric_titles = _metric_titles()
+    metrics = [m for m in metric_titles if any(row.metric == m for row in rows)]
+    if not metrics:
+        return paths
+
+    rows_by_metric: Dict[str, List[ConfigMetricSummary]] = {
+        metric: sorted(
+            [row for row in rows if row.metric == metric], key=lambda row: row.config
+        )
+        for metric in metrics
+    }
+
+    n_cols = 2
+    n_rows = (len(metrics) + n_cols - 1) // n_cols
+    fig, axes = plt.subplots(n_rows, n_cols, figsize=(14, 4 * n_rows), squeeze=False)
+
+    for idx, metric in enumerate(metrics):
+        ax = axes[idx // n_cols][idx % n_cols]
+        metric_rows = rows_by_metric[metric]
+        labels = [_simplify_label(row.config) for row in metric_rows]
+        rmse_values = [row.rmse for row in metric_rows]
+        noise = [row.noise_ceiling for row in metric_rows]
+        x = list(range(len(labels)))
+        ax.bar(x, rmse_values, yerr=noise, capsize=3, label="RMSE (±1 human std)")
         ax.set_xticks(x)
         ax.set_xticklabels(labels, rotation=45, ha="right")
-        ax.set_ylabel(title)
-        ax.set_title(f"{title} by configuration")
+        ax.set_ylabel("RMSE")
+        ax.set_title(metric_titles.get(metric, metric))
         ax.legend()
-        fig.tight_layout()
 
-        output_path = output_dir / f"config_{key}_noise_ceiling.png"
-        fig.savefig(output_path)
-        plt.close(fig)
-        paths.append(output_path)
+    for idx in range(len(metrics), n_rows * n_cols):
+        fig.delaxes(axes[idx // n_cols][idx % n_cols])
+
+    fig.tight_layout()
+    output_path = output_dir / "config_rmse_by_metric.png"
+    fig.savefig(output_path)
+    plt.close(fig)
+    paths.append(output_path)
+    return paths
+
+
+def _bootstrap_rmse(
+    rmse_values: List[float], n_boot: int = 2000, seed: int = 7
+) -> Tuple[float, float]:
+    if not rmse_values:
+        return 0.0, 0.0
+    import random
+
+    rng = random.Random(seed)
+    n = len(rmse_values)
+    squared = [value * value for value in rmse_values]
+    bootstrap: List[float] = []
+    for _ in range(n_boot):
+        sample = [squared[rng.randrange(n)] for _ in range(n)]
+        bootstrap.append((sum(sample) / n) ** 0.5)
+    mean_rmse = (sum(squared) / n) ** 0.5
+    mean_boot = sum(bootstrap) / n_boot
+    variance = sum((value - mean_boot) ** 2 for value in bootstrap) / n_boot
+    return mean_rmse, variance**0.5
+
+
+def plot_aggregate_metric_rmse(
+    output_dir: Path, rows: List[ConfigMetricSummary]
+) -> List[Path]:
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        return []
+
+    paths: List[Path] = []
+    if not rows:
+        return paths
+
+    metric_titles = _metric_titles()
+    grouped: Dict[str, List[ConfigMetricSummary]] = {}
+    for row in rows:
+        if row.metric not in metric_titles:
+            continue
+        grouped.setdefault(row.metric, []).append(row)
+
+    metrics = [m for m in metric_titles if m in grouped]
+    if not metrics:
+        return paths
+
+    labels = [metric_titles[m] for m in metrics]
+    rmse_values: List[float] = []
+    rmse_errors: List[float] = []
+    noise_values: List[float] = []
+
+    for metric in metrics:
+        metric_rows = grouped[metric]
+        config_rmse = [row.rmse for row in metric_rows]
+        aggregate_rmse, rmse_err = _bootstrap_rmse(config_rmse)
+        rmse_values.append(aggregate_rmse)
+        rmse_errors.append(rmse_err)
+        noise_rms = (
+            sum(row.noise_ceiling ** 2 for row in metric_rows) / len(metric_rows)
+        ) ** 0.5
+        noise_values.append(noise_rms)
+
+    x = list(range(len(metrics)))
+    width = 0.35
+    fig, ax = plt.subplots(figsize=(10, 5))
+    ax.bar(x, rmse_values, width=width, yerr=rmse_errors, capsize=4, label="RMSE")
+    ax.bar(
+        [i + width for i in x],
+        noise_values,
+        width=width,
+        label="Noise ceiling (human std)",
+    )
+    ax.set_xticks([i + width / 2 for i in x])
+    ax.set_xticklabels(labels, rotation=30, ha="right")
+    ax.set_ylabel("RMSE")
+    ax.set_title("Aggregate RMSE across configurations")
+    ax.legend()
+    fig.tight_layout()
+
+    output_path = output_dir / "aggregate_rmse_by_metric.png"
+    fig.savefig(output_path)
+    plt.close(fig)
+    paths.append(output_path)
     return paths


### PR DESCRIPTION
### Motivation
- Provide an aggregated RMSE view across all validation configurations while keeping per-config panels, and make the noise ceiling use human standard deviation (STD) rather than SEM so RMSE and noise ceiling share the same units and calculation basis. 
- Produce consolidated, interpretable figures for the requested metrics (contribution, efficiency, payoff, punishment rate, reward rate) and add principled error bars for the aggregate view.

### Description
- Updated `Analysis_robin/comparison.py` to record human standard deviation per config/metric (`human_std`) and to emit per-config, per-metric `ConfigMetricSummary` rows (added `metric` and `n_samples`, changed CSV columns to `config,metric,rmse,noise_ceiling,n_samples`).
- Replaced the old noise-ceiling plotting functions with two new plotting routines in `Analysis_robin/plotting.py`: `plot_config_metric_rmse` which makes subplots of RMSE per configuration for each metric using the human-STD as the noise ceiling, and `plot_aggregate_metric_rmse` which computes aggregate RMSE across configs and error bars via bootstrap over configs (helper `_bootstrap_rmse`).
- Added a small metric title map (`_metric_titles`) and adapted plotting layouts (grid of subplots for per-metric config panels and a separate aggregate bar plot saved as `config_rmse_by_metric.png` and `aggregate_rmse_by_metric.png`).
- Wired the new plotting functions into `Analysis_robin/analyze.py` and updated the `manifest` notes to describe the new RMSE/noise-ceiling choices.

### Testing
- No automated tests were executed on these changes in this rollout; the changes were limited to analysis/plotting logic and CSV output format and should be validated by running `python -m Analysis_robin.analyze` on sample simulation and human CSVs to confirm outputs and generated PNGs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c0ca9343c833181217dd6dfa697bf)