### PR TITLE
Update simulation vs human comparison plots: drop payoff, add noise ceiling and mean comparison

### DIFF
--- a/Analysis_robin/analyze.py
+++ b/Analysis_robin/analyze.py
@@ -27,7 +27,11 @@ from .config import (
     DEFAULT_OUTPUT_ROOT,
 )
 from .io_utils import load_human_rows, load_simulation_runs
-from .plotting import plot_aggregate_metric_rmse, plot_config_metric_rmse
+from .plotting import (
+    plot_aggregate_metric_rmse,
+    plot_config_metric_rmse,
+    plot_metric_means_by_config,
+)
 
 
 def _timestamp() -> str:
@@ -102,7 +106,6 @@ def main() -> None:
 
     metrics = [
         "mean_contribution_rate",
-        "mean_payoff",
         "punishment_rate",
         "reward_rate",
         "normalized_efficiency",
@@ -122,6 +125,7 @@ def main() -> None:
 
     plot_config_metric_rmse(output_dir, config_metric_summaries)
     plot_aggregate_metric_rmse(output_dir, config_metric_summaries)
+    plot_metric_means_by_config(output_dir, alignment_rows)
 
     manifest = {
         "timestamp": timestamp,
@@ -132,7 +136,8 @@ def main() -> None:
         "metrics": metrics,
         "notes": (
             "RMSE plotted with human standard deviation as the noise ceiling. "
-            "Aggregate RMSE uses bootstrap standard deviation across configs for error bars."
+            "Aggregate RMSE uses bootstrap standard deviation across configs for error bars. "
+            "Metric mean plots compare simulation vs human means with human std error bars."
         ),
     }
     with (output_dir / "manifest.json").open("w", encoding="utf-8") as handle:


### PR DESCRIPTION
### Motivation
- Remove `mean_payoff` from the set of simulation-vs-human comparison metrics to focus on the requested metrics.
- Surface the human noise ceiling (std) alongside RMSE per configuration so readers can easily compare model error vs human variability.
- Provide direct per-config comparisons of simulation and human means (with human std) to help identify systematic over/under-estimation by the simulation.

### Description
- Removed `"mean_payoff"` from the analysis metric list used in `Analysis_robin/analyze.py` and updated the manifest notes accordingly.
- Updated `plot_config_metric_rmse` in `Analysis_robin/plotting.py` to plot RMSE and the noise ceiling as side-by-side bars per config instead of using `yerr` on a single bar.
- Added a new function `plot_metric_means_by_config` in `Analysis_robin/plotting.py` that creates per-config bar plots comparing `sim_mean` vs `human_mean` with human standard deviation error bars.
- Hooked the new plot into the analysis pipeline by calling `plot_metric_means_by_config(output_dir, alignment_rows)` from `analyze.py`.

### Testing
- No automated tests were run for these plotting changes.
- The repository changes were staged and committed locally; plotting functions will execute during normal runs of `Analysis_robin/analyze.py` when `matplotlib` is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c0f88cdd08331b015f2ba83f9e2ef)