### PR TITLE
Add binary-config labels, multi-run loading, and aggregate/variance/binary plots

### DIFF
--- a/Analysis_robin/analyze.py
+++ b/Analysis_robin/analyze.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from datetime import datetime
 from pathlib import Path
+from typing import Iterable, List, Tuple
 
 from .aggregation import (
     summarize_by_game,
+    summarize_by_game_with_config,
     summarize_by_player,
     summarize_by_round,
     write_game_summary,
@@ -29,13 +32,140 @@ from .config import (
 from .io_utils import load_human_rows, load_simulation_runs
 from .plotting import (
     plot_aggregate_metric_rmse,
+    plot_aggregate_metric_means,
     plot_config_metric_rmse,
+    plot_metric_variance_by_config,
     plot_metric_means_by_config,
+    plot_metrics_by_binary_config,
 )
 
 
 def _timestamp() -> str:
     return datetime.now().strftime("%y%m%d%H%M")
+
+
+def _humanize_config_key(config_key: str) -> str:
+    label = config_key.replace("CONFIG_", "")
+    label = label.replace("_", " ")
+    label = re.sub(r"([a-z])([A-Z])", r"\1 \2", label)
+    return label.strip().title()
+
+
+def _binarize_value(config_key: str, value: object) -> Tuple[bool, bool]:
+    if config_key == "CONFIG_defaultContribProp":
+        try:
+            return True, float(value) > 0
+        except (TypeError, ValueError):
+            return False, False
+    if isinstance(value, bool):
+        return True, value
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return False, False
+    if numeric in (0.0, 1.0):
+        return True, bool(numeric)
+    return False, False
+
+
+def _config_value_label(config_key: str, value: bool) -> str:
+    if config_key == "CONFIG_chat":
+        return "Communication" if value else "No communication"
+    if config_key == "CONFIG_allOrNothing":
+        return "Binary contribution" if value else "Continuous contribution"
+    if config_key == "CONFIG_defaultContribProp":
+        return "Opt-out" if value else "Opt-in"
+    if config_key == "CONFIG_showOtherSummaries":
+        return "Peer outcomes visible" if value else "Peer outcomes hidden"
+    if config_key == "CONFIG_showPunishmentId":
+        return "Punisher identity revealed" if value else "Punisher identity hidden"
+    if config_key == "CONFIG_showNRounds":
+        return "Known horizon" if value else "Unknown horizon"
+    if config_key == "CONFIG_rewardExists":
+        return "Reward exists" if value else "No rewards"
+    if config_key == "CONFIG_punishmentExists":
+        return "Punishment exists" if value else "No punishment"
+    return "Yes" if value else "No"
+
+
+def _config_title(config_key: str) -> str:
+    if config_key == "CONFIG_chat":
+        return "Communication"
+    if config_key == "CONFIG_allOrNothing":
+        return "Contribution mode"
+    if config_key == "CONFIG_defaultContribProp":
+        return "Default contribution"
+    if config_key == "CONFIG_showOtherSummaries":
+        return "Peer outcome visibility"
+    if config_key == "CONFIG_showPunishmentId":
+        return "Punisher identity revealed"
+    if config_key == "CONFIG_showNRounds":
+        return "Horizon knowledge"
+    if config_key == "CONFIG_rewardExists":
+        return "Reward exists"
+    if config_key == "CONFIG_punishmentExists":
+        return "Punishment exists"
+    return _humanize_config_key(config_key)
+
+
+def _collect_binary_keys(game_details) -> List[str]:
+    values = {}
+    for item in game_details:
+        for key, value in item.config.environment.items():
+            if not key.startswith("CONFIG_"):
+                continue
+            ok, binary = _binarize_value(key, value)
+            if not ok:
+                continue
+            values.setdefault(key, set()).add(binary)
+    return [key for key, vals in sorted(values.items()) if len(vals) == 2]
+
+
+def _build_binary_config_rows(
+    sim_games,
+    human_games,
+    metrics: Iterable[str],
+) -> List[Tuple[str, str, str, str, float, float]]:
+    rows: List[Tuple[str, str, str, str, float, float]] = []
+    all_games = list(sim_games) + list(human_games)
+    binary_keys = _collect_binary_keys(all_games)
+    for config_key in binary_keys:
+        for metric in metrics:
+            for value in (False, True):
+                sim_values = []
+                for item in sim_games:
+                    ok, binary = _binarize_value(
+                        config_key, item.config.environment.get(config_key)
+                    )
+                    if ok and binary == value:
+                        metric_value = item.metrics.get(metric)
+                        if metric_value is not None:
+                            sim_values.append(metric_value)
+                human_values = []
+                for item in human_games:
+                    ok, binary = _binarize_value(
+                        config_key, item.config.environment.get(config_key)
+                    )
+                    if ok and binary == value:
+                        metric_value = item.metrics.get(metric)
+                        if metric_value is not None:
+                            human_values.append(metric_value)
+                if not sim_values or not human_values:
+                    continue
+                sim_mean = sum(sim_values) / len(sim_values)
+                human_mean = sum(human_values) / len(human_values)
+                rows.append(
+                    (
+                        config_key,
+                        _config_title(config_key),
+                        _config_value_label(config_key, value),
+                        metric,
+                        sim_mean,
+                        human_mean,
+                    )
+                )
+    return rows
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Analyze PGG simulation vs human data")
@@ -63,9 +193,31 @@ def main() -> None:
         default=DEFAULT_HUMAN_CONFIG_CSV,
         help="Human config mapping CSV.",
     )
+    parser.add_argument(
+        "--sim-include-all",
+        action="store_true",
+        help="Include all simulation runs per config instead of only the latest.",
+    )
+    parser.add_argument(
+        "--sim-filter",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help=(
+            "Filter simulation runs by config.json values. Use dotted paths like "
+            "'model.base_model=...'. Can be specified multiple times."
+        ),
+    )
     args = parser.parse_args()
 
-    sim_rows = load_simulation_runs(args.output_root)
+    filter_pairs = dict(
+        item.split("=", 1) for item in args.sim_filter if "=" in item
+    )
+    sim_rows = load_simulation_runs(
+        args.output_root,
+        include_all_runs=args.sim_include_all,
+        config_filters=filter_pairs,
+    )
     human_rows = load_human_rows(args.human_rounds, args.human_configs)
 
     timestamp = _timestamp()
@@ -126,6 +278,51 @@ def main() -> None:
     plot_config_metric_rmse(output_dir, config_metric_summaries)
     plot_aggregate_metric_rmse(output_dir, config_metric_summaries)
     plot_metric_means_by_config(output_dir, alignment_rows)
+    plot_aggregate_metric_means(output_dir, alignment_rows)
+
+    variance_metrics = [
+        "mean_contribution_rate",
+        "punishment_rate",
+        "reward_rate",
+        "mean_payoff",
+    ]
+    variance_rows = []
+    for config_name, sim_summary in sim_player_summary.items():
+        human_summary = human_player_summary.get(config_name)
+        if not human_summary:
+            continue
+        for metric in variance_metrics:
+            sim_values = [row.metrics.get(metric) for row in sim_summary]
+            human_values = [row.metrics.get(metric) for row in human_summary]
+            sim_values = [value for value in sim_values if value is not None]
+            human_values = [value for value in human_values if value is not None]
+            if not sim_values or not human_values:
+                continue
+            sim_mean = sum(sim_values) / len(sim_values)
+            human_mean = sum(human_values) / len(human_values)
+            sim_var = sum((value - sim_mean) ** 2 for value in sim_values) / len(sim_values)
+            human_var = (
+                sum((value - human_mean) ** 2 for value in human_values) / len(human_values)
+            )
+            variance_rows.append((config_name, metric, sim_var, human_var))
+    plot_metric_variance_by_config(output_dir, variance_rows)
+
+    sim_game_details = [
+        item
+        for rows in sim_rows.values()
+        for item in summarize_by_game_with_config(rows)
+    ]
+    human_game_details = [
+        item
+        for rows in human_rows.values()
+        for item in summarize_by_game_with_config(rows)
+    ]
+    binary_rows = _build_binary_config_rows(
+        sim_game_details,
+        human_game_details,
+        variance_metrics,
+    )
+    plot_metrics_by_binary_config(output_dir, binary_rows)
 
     manifest = {
         "timestamp": timestamp,
@@ -133,7 +330,10 @@ def main() -> None:
         "analysis_output_root": str(args.analysis_output_root),
         "human_rounds": str(args.human_rounds),
         "human_configs": str(args.human_configs),
+        "sim_include_all": args.sim_include_all,
+        "sim_filters": filter_pairs,
         "metrics": metrics,
+        "variance_metrics": variance_metrics,
         "notes": (
             "RMSE plotted with human standard deviation as the noise ceiling. "
             "Aggregate RMSE uses bootstrap standard deviation across configs for error bars. "

--- a/Analysis_robin/plotting.py
+++ b/Analysis_robin/plotting.py
@@ -18,6 +18,7 @@ def _metric_titles() -> Dict[str, str]:
         "normalized_efficiency": "Normalized efficiency",
         "punishment_rate": "Punishment rate",
         "reward_rate": "Reward rate",
+        "mean_payoff": "Payoff",
     }
 
 
@@ -225,4 +226,202 @@ def plot_metric_means_by_config(
     fig.savefig(output_path)
     plt.close(fig)
     paths.append(output_path)
+    return paths
+
+
+def plot_aggregate_metric_means(
+    output_dir: Path, alignment_rows: List[AlignmentRow]
+) -> List[Path]:
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        return []
+
+    paths: List[Path] = []
+    if not alignment_rows:
+        return paths
+
+    metric_titles = _metric_titles()
+    metrics = [m for m in metric_titles if any(row.metric == m for row in alignment_rows)]
+    if not metrics:
+        return paths
+
+    grouped: Dict[str, List[AlignmentRow]] = {}
+    for row in alignment_rows:
+        if row.metric in metric_titles:
+            grouped.setdefault(row.metric, []).append(row)
+
+    sim_means: List[float] = []
+    human_means: List[float] = []
+    sim_std: List[float] = []
+    human_std: List[float] = []
+    labels: List[str] = []
+
+    for metric in metrics:
+        rows = grouped.get(metric, [])
+        if not rows:
+            continue
+        labels.append(metric_titles.get(metric, metric))
+        sim_values = [row.sim_mean for row in rows]
+        human_values = [row.human_mean for row in rows]
+        sim_mean = sum(sim_values) / len(sim_values)
+        human_mean = sum(human_values) / len(human_values)
+        sim_means.append(sim_mean)
+        human_means.append(human_mean)
+        sim_var = (
+            sum((value - sim_mean) ** 2 for value in sim_values) / len(sim_values)
+            if sim_values
+            else 0.0
+        )
+        human_var = (
+            sum((value - human_mean) ** 2 for value in human_values) / len(human_values)
+            if human_values
+            else 0.0
+        )
+        sim_std.append(sim_var**0.5)
+        human_std.append(human_var**0.5)
+
+    x = list(range(len(labels)))
+    width = 0.35
+    fig, ax = plt.subplots(figsize=(10, 5))
+    ax.bar(x, sim_means, width=width, yerr=sim_std, capsize=4, label="Simulation mean")
+    ax.bar(
+        [i + width for i in x],
+        human_means,
+        width=width,
+        yerr=human_std,
+        capsize=4,
+        label="Human mean",
+    )
+    ax.set_xticks([i + width / 2 for i in x])
+    ax.set_xticklabels(labels, rotation=30, ha="right")
+    ax.set_ylabel("Mean value")
+    ax.set_title("Aggregate metric means across configurations")
+    ax.legend()
+    fig.tight_layout()
+    output_path = output_dir / "metric_means_aggregate.png"
+    fig.savefig(output_path)
+    plt.close(fig)
+    paths.append(output_path)
+    return paths
+
+
+def plot_metric_variance_by_config(
+    output_dir: Path,
+    variance_rows: List[Tuple[str, str, float, float]],
+) -> List[Path]:
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        return []
+
+    paths: List[Path] = []
+    if not variance_rows:
+        return paths
+
+    metric_titles = _metric_titles()
+    metrics = [m for m in metric_titles if any(row[1] == m for row in variance_rows)]
+    if not metrics:
+        return paths
+
+    rows_by_metric: Dict[str, List[Tuple[str, str, float, float]]] = {
+        metric: sorted(
+            [row for row in variance_rows if row[1] == metric], key=lambda row: row[0]
+        )
+        for metric in metrics
+    }
+
+    n_cols = 2
+    n_rows = (len(metrics) + n_cols - 1) // n_cols
+    fig, axes = plt.subplots(n_rows, n_cols, figsize=(14, 4 * n_rows), squeeze=False)
+
+    for idx, metric in enumerate(metrics):
+        ax = axes[idx // n_cols][idx % n_cols]
+        metric_rows = rows_by_metric[metric]
+        labels = [_simplify_label(row[0]) for row in metric_rows]
+        sim_vars = [row[2] for row in metric_rows]
+        human_vars = [row[3] for row in metric_rows]
+        x = list(range(len(labels)))
+        width = 0.35
+        ax.bar(x, sim_vars, width=width, label="Simulation variance")
+        ax.bar(
+            [i + width for i in x],
+            human_vars,
+            width=width,
+            label="Human variance",
+        )
+        ax.set_xticks([i + width / 2 for i in x])
+        ax.set_xticklabels(labels, rotation=45, ha="right")
+        ax.set_ylabel("Variance")
+        ax.set_title(metric_titles.get(metric, metric))
+        ax.legend()
+
+    for idx in range(len(metrics), n_rows * n_cols):
+        fig.delaxes(axes[idx // n_cols][idx % n_cols])
+
+    fig.tight_layout()
+    output_path = output_dir / "metric_variance_by_config.png"
+    fig.savefig(output_path)
+    plt.close(fig)
+    paths.append(output_path)
+    return paths
+
+
+def plot_metrics_by_binary_config(
+    output_dir: Path,
+    rows: List[Tuple[str, str, str, str, float, float]],
+) -> List[Path]:
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        return []
+
+    paths: List[Path] = []
+    if not rows:
+        return paths
+
+    metric_titles = _metric_titles()
+    grouped: Dict[str, List[Tuple[str, str, str, str, float, float]]] = {}
+    for row in rows:
+        grouped.setdefault(row[0], []).append(row)
+
+    for config_key, config_rows in grouped.items():
+        config_label = config_rows[0][1]
+        metrics = [m for m in metric_titles if any(r[3] == m for r in config_rows)]
+        if not metrics:
+            continue
+        n_cols = 2
+        n_rows = (len(metrics) + n_cols - 1) // n_cols
+        fig, axes = plt.subplots(n_rows, n_cols, figsize=(12, 4 * n_rows), squeeze=False)
+        for idx, metric in enumerate(metrics):
+            ax = axes[idx // n_cols][idx % n_cols]
+            metric_rows = [r for r in config_rows if r[3] == metric]
+            metric_rows = sorted(metric_rows, key=lambda r: r[2])
+            labels = [r[2] for r in metric_rows]
+            sim_values = [r[4] for r in metric_rows]
+            human_values = [r[5] for r in metric_rows]
+            x = list(range(len(labels)))
+            width = 0.35
+            ax.bar(x, sim_values, width=width, label="Simulation mean")
+            ax.bar(
+                [i + width for i in x],
+                human_values,
+                width=width,
+                label="Human mean",
+            )
+            ax.set_xticks([i + width / 2 for i in x])
+            ax.set_xticklabels(labels, rotation=30, ha="right")
+            ax.set_ylabel("Mean value")
+            ax.set_title(metric_titles.get(metric, metric))
+            ax.legend()
+
+        for idx in range(len(metrics), n_rows * n_cols):
+            fig.delaxes(axes[idx // n_cols][idx % n_cols])
+
+        fig.suptitle(config_label, y=1.02)
+        fig.tight_layout()
+        output_path = output_dir / f"metric_means_by_{config_key.lower()}.png"
+        fig.savefig(output_path, bbox_inches="tight")
+        plt.close(fig)
+        paths.append(output_path)
     return paths


### PR DESCRIPTION
### Motivation
- Add human-friendly labels/titles for several binary `CONFIG_` keys including `CONFIG_showOtherSummaries`, `CONFIG_showPunishmentId`, `CONFIG_showNRounds`, `CONFIG_rewardExists`, and `CONFIG_punishmentExists` so aggregate/binary-config plots read clearly.
- Support comparing multiple simulation realizations per config and multiple human experiments per config so comparisons can mirror real experiment multiplicity.
- Provide aggregate summaries and visualizations (means across configs, variance comparisons, and binary-config comparisons) and allow filtering simulation runs by `config.json` fields (including dotted paths like `model.include_reasoning`).

### Description
- Preserve per-run config when summarizing by adding `GameSummary` and `summarize_by_game_with_config` and update `summarize_by_game` to call it so downstream code can access `GameConfig` for each game (file: `Analysis_robin/aggregation.py`).
- Extend `load_simulation_runs` to support `include_all_runs`, `--sim-filter` parsing and matching (dotted path resolution), run ordering, and optional `game_id` run-prefixing; added helper functions `_parse_filter_value`, `_resolve_path`, and `_matches_filters` to perform robust filter matching (file: `Analysis_robin/io_utils.py`).
- Add CLI flags `--sim-include-all` and `--sim-filter KEY=VALUE` to `analyze.py`, add `--sim_filters`/`sim_include_all` to the analysis manifest, and implement binarization/humanization helpers (`_binarize_value`, `_humanize_config_key`, `_config_value_label`, `_config_title`) to render readable labels (file: `Analysis_robin/analyze.py`).
- Implement aggregate/variance/binary plotting utilities: `plot_aggregate_metric_means` (aggregate means with error bars), `plot_metric_variance_by_config` (per-config variance comparison), and `plot_metrics_by_binary_config` (compare sim vs human across binary config splits); also add `mean_payoff` to metric titles (file: `Analysis_robin/plotting.py`).
- Build binary-config comparison rows by collecting binary `CONFIG_` keys present across sim+human datasets and computing per-value means so the new plotting utilities can render those comparisons (file: `Analysis_robin/analyze.py`).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ca2e18d8483318fca53f018e936fe)