### PR TITLE
Fix non-string filter parsing and add dual-model analysis + plotting support

### DIFF
--- a/Analysis_robin/analyze.py
+++ b/Analysis_robin/analyze.py
@@ -5,9 +5,10 @@ import json
 import re
 from datetime import datetime
 from pathlib import Path
-from typing import Iterable, List, Tuple
+from typing import Dict, Iterable, List, Tuple
 
 from .aggregation import (
+    SummaryRow,
     summarize_by_game,
     summarize_by_game_with_config,
     summarize_by_player,
@@ -121,26 +122,19 @@ def _collect_binary_keys(game_details) -> List[str]:
     return [key for key, vals in sorted(values.items()) if len(vals) == 2]
 
 
-def _build_binary_config_rows(
-    sim_games,
+def _build_binary_config_rows_by_model(
+    sim_games_by_model,
     human_games,
     metrics: Iterable[str],
-) -> List[Tuple[str, str, str, str, float, float]]:
-    rows: List[Tuple[str, str, str, str, float, float]] = []
-    all_games = list(sim_games) + list(human_games)
+) -> List[Tuple[str, str, str, str, str, float, float]]:
+    rows: List[Tuple[str, str, str, str, str, float, float]] = []
+    all_games = [item for games in sim_games_by_model.values() for item in games] + list(
+        human_games
+    )
     binary_keys = _collect_binary_keys(all_games)
     for config_key in binary_keys:
         for metric in metrics:
             for value in (False, True):
-                sim_values = []
-                for item in sim_games:
-                    ok, binary = _binarize_value(
-                        config_key, item.config.environment.get(config_key)
-                    )
-                    if ok and binary == value:
-                        metric_value = item.metrics.get(metric)
-                        if metric_value is not None:
-                            sim_values.append(metric_value)
                 human_values = []
                 for item in human_games:
                     ok, binary = _binarize_value(
@@ -150,21 +144,49 @@ def _build_binary_config_rows(
                         metric_value = item.metrics.get(metric)
                         if metric_value is not None:
                             human_values.append(metric_value)
-                if not sim_values or not human_values:
+                if not human_values:
                     continue
-                sim_mean = sum(sim_values) / len(sim_values)
                 human_mean = sum(human_values) / len(human_values)
-                rows.append(
-                    (
-                        config_key,
-                        _config_title(config_key),
-                        _config_value_label(config_key, value),
-                        metric,
-                        sim_mean,
-                        human_mean,
+                for model_key, sim_games in sim_games_by_model.items():
+                    sim_values = []
+                    for item in sim_games:
+                        ok, binary = _binarize_value(
+                            config_key, item.config.environment.get(config_key)
+                        )
+                        if ok and binary == value:
+                            metric_value = item.metrics.get(metric)
+                            if metric_value is not None:
+                                sim_values.append(metric_value)
+                    if not sim_values:
+                        continue
+                    sim_mean = sum(sim_values) / len(sim_values)
+                    rows.append(
+                        (
+                            config_key,
+                            _config_title(config_key),
+                            _config_value_label(config_key, value),
+                            metric,
+                            model_key,
+                            sim_mean,
+                            human_mean,
+                        )
                     )
-                )
     return rows
+
+
+def _variance_by_config(
+    summaries: Dict[str, List[SummaryRow]], metrics: Iterable[str]
+) -> Dict[str, Dict[str, float]]:
+    variance: Dict[str, Dict[str, float]] = {}
+    for config_name, rows in summaries.items():
+        for metric in metrics:
+            values = [row.metrics.get(metric) for row in rows if row.metrics.get(metric) is not None]
+            if not values:
+                continue
+            mean_value = sum(values) / len(values)
+            var = sum((value - mean_value) ** 2 for value in values) / len(values)
+            variance.setdefault(config_name, {})[metric] = var
+    return variance
 
 
 def main() -> None:
@@ -213,116 +235,138 @@ def main() -> None:
     filter_pairs = dict(
         item.split("=", 1) for item in args.sim_filter if "=" in item
     )
-    sim_rows = load_simulation_runs(
-        args.output_root,
-        include_all_runs=args.sim_include_all,
-        config_filters=filter_pairs,
-    )
+    model_specs = [
+        ("no_reasoning", "No reasoning", False),
+        ("with_reasoning", "With reasoning", True),
+    ]
+    sim_rows_by_model = {}
+    for model_key, _, include_reasoning in model_specs:
+        model_filters = dict(filter_pairs)
+        model_filters["include_reasoning"] = include_reasoning
+        sim_rows_by_model[model_key] = load_simulation_runs(
+            args.output_root,
+            include_all_runs=args.sim_include_all,
+            config_filters=model_filters,
+        )
     human_rows = load_human_rows(args.human_rounds, args.human_configs)
 
     timestamp = _timestamp()
     output_dir = args.analysis_output_root / timestamp
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    sim_game_summary = {
-        config: summarize_by_game(rows) for config, rows in sim_rows.items()
+    sim_game_summary_by_model = {
+        model_key: {config: summarize_by_game(rows) for config, rows in sim_rows.items()}
+        for model_key, sim_rows in sim_rows_by_model.items()
     }
     human_game_summary = {
         config: summarize_by_game(rows) for config, rows in human_rows.items()
     }
-    sim_player_summary = {
-        config: summarize_by_player(rows) for config, rows in sim_rows.items()
+    sim_player_summary_by_model = {
+        model_key: {config: summarize_by_player(rows) for config, rows in sim_rows.items()}
+        for model_key, sim_rows in sim_rows_by_model.items()
     }
     human_player_summary = {
         config: summarize_by_player(rows) for config, rows in human_rows.items()
     }
-    sim_round_summary = {
-        config: summarize_by_round(rows) for config, rows in sim_rows.items()
+    sim_round_summary_by_model = {
+        model_key: {config: summarize_by_round(rows) for config, rows in sim_rows.items()}
+        for model_key, sim_rows in sim_rows_by_model.items()
     }
     human_round_summary = {
         config: summarize_by_round(rows) for config, rows in human_rows.items()
     }
 
-    for config, summary in sim_game_summary.items():
-        write_game_summary(output_dir / f"sim_game_summary_{config}.csv", summary)
+    for model_key, sim_game_summary in sim_game_summary_by_model.items():
+        for config, summary in sim_game_summary.items():
+            write_game_summary(
+                output_dir / f"sim_game_summary_{model_key}_{config}.csv", summary
+            )
     for config, summary in human_game_summary.items():
         write_game_summary(output_dir / f"human_game_summary_{config}.csv", summary)
-    for config, summary in sim_player_summary.items():
-        write_player_summary(output_dir / f"sim_player_summary_{config}.csv", summary)
+    for model_key, sim_player_summary in sim_player_summary_by_model.items():
+        for config, summary in sim_player_summary.items():
+            write_player_summary(
+                output_dir / f"sim_player_summary_{model_key}_{config}.csv", summary
+            )
     for config, summary in human_player_summary.items():
         write_player_summary(output_dir / f"human_player_summary_{config}.csv", summary)
-    for config, summary in sim_round_summary.items():
-        write_round_summary(output_dir / f"sim_round_summary_{config}.csv", summary)
+    for model_key, sim_round_summary in sim_round_summary_by_model.items():
+        for config, summary in sim_round_summary.items():
+            write_round_summary(
+                output_dir / f"sim_round_summary_{model_key}_{config}.csv", summary
+            )
     for config, summary in human_round_summary.items():
         write_round_summary(output_dir / f"human_round_summary_{config}.csv", summary)
 
-    metrics = [
+    core_metrics = [
         "mean_contribution_rate",
         "punishment_rate",
         "reward_rate",
         "normalized_efficiency",
     ]
-    alignment_rows, metric_summaries = compare_configs(
-        sim_game_summary, human_game_summary, metrics
+    alignment_rows_by_model = {}
+    metric_summaries_by_model = {}
+    config_metric_summaries_by_model = {}
+    for model_key, sim_game_summary in sim_game_summary_by_model.items():
+        alignment_rows, metric_summaries = compare_configs(
+            sim_game_summary, human_game_summary, core_metrics
+        )
+        config_metric_summaries = compare_by_config(
+            sim_game_summary, human_game_summary, core_metrics
+        )
+        alignment_rows_by_model[model_key] = alignment_rows
+        metric_summaries_by_model[model_key] = metric_summaries
+        config_metric_summaries_by_model[model_key] = config_metric_summaries
+
+        write_alignment(
+            output_dir / f"alignment_game_summary_{model_key}.csv", alignment_rows
+        )
+        write_metric_summary(
+            output_dir / f"alignment_metric_summary_{model_key}.csv", metric_summaries
+        )
+        write_config_metric_summary(
+            output_dir / f"alignment_config_metric_summary_{model_key}.csv",
+            config_metric_summaries,
+        )
+
+    model_labels = {key: label for key, label, _ in model_specs}
+    plot_config_metric_rmse(output_dir, config_metric_summaries_by_model, model_labels)
+    plot_aggregate_metric_rmse(
+        output_dir, config_metric_summaries_by_model, model_labels
     )
-    config_metric_summaries = compare_by_config(
-        sim_game_summary, human_game_summary, metrics
+    plot_metric_means_by_config(
+        output_dir, alignment_rows_by_model, model_labels, human_game_summary, core_metrics
+    )
+    plot_aggregate_metric_means(
+        output_dir, alignment_rows_by_model, model_labels, core_metrics
     )
 
-    write_alignment(output_dir / "alignment_game_summary.csv", alignment_rows)
-    write_metric_summary(output_dir / "alignment_metric_summary.csv", metric_summaries)
-    write_config_metric_summary(
-        output_dir / "alignment_config_metric_summary.csv", config_metric_summaries
+    variance_by_model = {
+        model_key: _variance_by_config(sim_summary, core_metrics)
+        for model_key, sim_summary in sim_game_summary_by_model.items()
+    }
+    human_variance = _variance_by_config(human_game_summary, core_metrics)
+    plot_metric_variance_by_config(
+        output_dir, variance_by_model, human_variance, model_labels
     )
 
-    plot_config_metric_rmse(output_dir, config_metric_summaries)
-    plot_aggregate_metric_rmse(output_dir, config_metric_summaries)
-    plot_metric_means_by_config(output_dir, alignment_rows)
-    plot_aggregate_metric_means(output_dir, alignment_rows)
-
-    variance_metrics = [
-        "mean_contribution_rate",
-        "punishment_rate",
-        "reward_rate",
-        "mean_payoff",
-    ]
-    variance_rows = []
-    for config_name, sim_summary in sim_player_summary.items():
-        human_summary = human_player_summary.get(config_name)
-        if not human_summary:
-            continue
-        for metric in variance_metrics:
-            sim_values = [row.metrics.get(metric) for row in sim_summary]
-            human_values = [row.metrics.get(metric) for row in human_summary]
-            sim_values = [value for value in sim_values if value is not None]
-            human_values = [value for value in human_values if value is not None]
-            if not sim_values or not human_values:
-                continue
-            sim_mean = sum(sim_values) / len(sim_values)
-            human_mean = sum(human_values) / len(human_values)
-            sim_var = sum((value - sim_mean) ** 2 for value in sim_values) / len(sim_values)
-            human_var = (
-                sum((value - human_mean) ** 2 for value in human_values) / len(human_values)
-            )
-            variance_rows.append((config_name, metric, sim_var, human_var))
-    plot_metric_variance_by_config(output_dir, variance_rows)
-
-    sim_game_details = [
-        item
-        for rows in sim_rows.values()
-        for item in summarize_by_game_with_config(rows)
-    ]
+    sim_game_details_by_model = {
+        model_key: [
+            item for rows in sim_rows.values() for item in summarize_by_game_with_config(rows)
+        ]
+        for model_key, sim_rows in sim_rows_by_model.items()
+    }
     human_game_details = [
         item
         for rows in human_rows.values()
         for item in summarize_by_game_with_config(rows)
     ]
-    binary_rows = _build_binary_config_rows(
-        sim_game_details,
+    binary_rows = _build_binary_config_rows_by_model(
+        sim_game_details_by_model,
         human_game_details,
-        variance_metrics,
+        core_metrics,
     )
-    plot_metrics_by_binary_config(output_dir, binary_rows)
+    plot_metrics_by_binary_config(output_dir, binary_rows, model_labels)
 
     manifest = {
         "timestamp": timestamp,
@@ -332,12 +376,16 @@ def main() -> None:
         "human_configs": str(args.human_configs),
         "sim_include_all": args.sim_include_all,
         "sim_filters": filter_pairs,
-        "metrics": metrics,
-        "variance_metrics": variance_metrics,
+        "sim_models": [
+            {"key": key, "label": label, "include_reasoning": include_reasoning}
+            for key, label, include_reasoning in model_specs
+        ],
+        "metrics": core_metrics,
+        "variance_metrics": core_metrics,
         "notes": (
-            "RMSE plotted with human standard deviation as the noise ceiling. "
-            "Aggregate RMSE uses bootstrap standard deviation across configs for error bars. "
-            "Metric mean plots compare simulation vs human means with human std error bars."
+            "RMSE plotted per model with bootstrap standard deviation across configs for error bars. "
+            "Metric mean plots compare both simulation variants against human means "
+            "with human standard deviation error bars."
         ),
     }
     with (output_dir / "manifest.json").open("w", encoding="utf-8") as handle:

--- a/Analysis_robin/io_utils.py
+++ b/Analysis_robin/io_utils.py
@@ -75,7 +75,12 @@ def _sorted_run_dirs(config_dir: Path) -> List[Path]:
     return [run for _, run in sorted(numeric_runs, key=lambda item: item[0])]
 
 
-def _parse_filter_value(value: str) -> Any:
+def _parse_filter_value(value: Any) -> Any:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return None
+    value = str(value)
     lowered = value.strip().lower()
     if lowered in ("true", "false"):
         return lowered == "true"


### PR DESCRIPTION
### Motivation
- Prevent `AttributeError` when simulation filters include non-string values like `include_reasoning` booleans by making filter parsing robust to non-string inputs.
- Enable direct comparison of two simulation variants (with and without reasoning) and render consolidated plots that show both models alongside a human noise-ceiling for clearer interpretation.

### Description
- Update `Analysis_robin/io_utils.py` ` _parse_filter_value` to accept `bool` and `None` inputs and to safely coerce other values to strings before parsing.  
- Rework `Analysis_robin/analyze.py` to load two model variants (`no_reasoning` and `with_reasoning`), produce per-model summaries and CSVs, emit `sim_models` in the manifest, and wire per-model data into downstream comparison/plotting calls.  
- Add `_variance_by_config` helper and change binary-config aggregation to `_build_binary_config_rows_by_model` so binary comparisons include per-model rows (model key included in rows).  
- Rework `Analysis_robin/plotting.py` APIs and internals to accept `rows_by_model` / `alignment_rows_by_model` and `model_labels`, compute bar widths/offsets for multiple model bars plus a noise-ceiling/human bar, and update RMSE/means/variance plotting logic accordingly.

### Testing
- No automated tests were executed for these analysis and plotting changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cacf2fa24833186427cb9f8d9ecb0)