### PR TITLE
Fix metric title mapping for binary config plots

### DIFF
--- a/Analysis_robin/plotting.py
+++ b/Analysis_robin/plotting.py
@@ -38,6 +38,7 @@ def plot_config_metric_rmse(
         return paths
 
     metric_titles = _metric_titles()
+    title_to_metric = {title: key for key, title in metric_titles.items()}
     metrics = [
         m
         for m in metric_titles
@@ -526,6 +527,7 @@ def plot_metrics_by_binary_config(
         return paths
 
     metric_titles = _metric_titles()
+    title_to_metric = {title: key for key, title in metric_titles.items()}
     grouped: Dict[str, List[Tuple[str, str, str, str, str, float, float]]] = {}
     for row in rows:
         grouped.setdefault(row[0], []).append(row)


### PR DESCRIPTION
### Motivation
- Prevent a `NameError` in plotting when converting printed metric titles back to metric keys by ensuring a `title_to_metric` lookup exists where labels are parsed (the error occurred in `plot_metrics_by_binary_config`).

### Description
- Add a `title_to_metric = {title: key for key, title in metric_titles.items()}` lookup in the plotting functions that build/parse label text, including `plot_metrics_by_binary_config` and the related config-metric plotting code, so label titles map back to metric keys at plot time.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cb737df9883318cb8c64a00be2206)