### PR TITLE
Add persona ids to simulation CSV output

### DIFF
--- a/Simulation_robin/output_manager.py
+++ b/Simulation_robin/output_manager.py
@@ -60,6 +60,8 @@ def _model_config(args: Any, run_ts: str) -> Dict[str, Any]:
         "chat_max_new_tokens",
         "actions_max_new_tokens",
         "include_reasoning",
+        "persona",
+        "persona_pool",
         "max_parallel_games",
         "debug_print",
         "env_csv"

--- a/Simulation_robin/run_simulation.py
+++ b/Simulation_robin/run_simulation.py
@@ -65,6 +65,14 @@ class Args:
         default=False,
         metadata={"help": "If true, request a short Reasoning line followed by a strict Answer line."},
     )
+    persona: Optional[str] = field(
+        default=None,
+        metadata={"help": "Optional persona mode (e.g., random_full_transcript)."},
+    )
+    persona_pool: str = field(
+        default="Persona/transcripts_learn.jsonl",
+        metadata={"help": "JSONL file containing persona transcript entries."},
+    )
 
     debug_print: bool = False
     debug_level: str = field(


### PR DESCRIPTION
### Motivation
- Record which persona (participant id from the persona pool) was sampled for each avatar so persona assignments are reproducible and trackable in output rows.
- Ensure that within a game each avatar's persona mapping is consistent and stored alongside per-round simulation data.

### Description
- In `Simulation_robin/simulator.py` sample persona records as `{"participant", "text"}` and store a `persona_ids` mapping per avatar, prepending the sampled transcript to prompts when `persona == "random_full_transcript"`.
- Add a `persona` column to the CSV header and include `persona: persona_ids.get(av)` in each per-round `row` so `participant_sim.csv` contains the sampled participant id for each avatar.
- Add CLI/config fields `persona` and `persona_pool` to `Simulation_robin/run_simulation.py` so persona behavior can be configured from the CLI.
- Persist `persona` and `persona_pool` in the saved run `config.json` via `_model_config` in `Simulation_robin/output_manager.py`.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e5c246f748331aa652c89ad718e32)